### PR TITLE
[fix] inline <code> padding and font

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -122,6 +122,11 @@ code {
   border-radius: 3px;
   border: 0 none;
   margin: 0;
+  font-family: @family-code;
+}
+
+p code {
+  padding: 4px;
 }
 
 a {

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -11,14 +11,14 @@ body {
   color: @font-color;
   margin-bottom: 44px;
   -webkit-font-smoothing: antialiased;
-}
 
-strong {
-  font-weight: 600;
-}
+  @media (max-width: 800px) {
+    padding-top: 52px;
+  }
 
-.container {
-  max-width: 1020px;
+  .container {
+    max-width: 1020px;
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -110,6 +110,10 @@ select {
   height: 44px;
 }
 
+strong {
+  font-weight: 600;
+}
+
 code {
   padding: 3px 9px;
   color: @red;
@@ -132,18 +136,18 @@ a {
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
   margin-bottom: 2rem;
-  font-weight: 400;
   letter-spacing: 0;
   color: #262e33;
 }
 
 h1 {
   font-size: 36px;
+  font-weight: 400;
 }
 
 h2 {
-  font-size: 28px;
-  font-weight: 600;
+  font-size: 33px;
+  font-weight: 300;
 }
 
 h3 {
@@ -167,14 +171,6 @@ h6 {
   font-weight: 600;
 }
 
-// General styles
-
-body {
-  @media (max-width: 800px) {
-    padding-top: 52px;
-  }
-}
-
 figure {
   margin: 0;
 
@@ -182,11 +178,6 @@ figure {
     width: 100%;
     height: auto;
   }
-}
-
-h2 {
-  font-size: 33px;
-  font-weight: 300;
 }
 
 nav {

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -115,7 +115,7 @@ strong {
 }
 
 code {
-  padding: 3px 9px;
+  padding: 4px;
   color: @red;
   font-size: 100%;
   background-color: #fff2f2;
@@ -123,10 +123,6 @@ code {
   border: 0 none;
   margin: 0;
   font-family: @family-code;
-}
-
-p code {
-  padding: 4px;
 }
 
 a {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -303,6 +303,10 @@
         text-align: right;
         white-space: nowrap;
 
+        code {
+          padding: 3px 9px;
+        }
+
         br {
           & + em,
           & + strong,

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -161,19 +161,19 @@
     font-weight: 500;
   }
 
+  p {
+    line-height: 25px;
+    font-size: 14px;
+  }
+
   h1, h2, h3, h4 {
     margin-bottom: 1em;
     font-weight: 600;
   }
 
-  h3, h2 {
+  h2, h3 {
     font-weight: 600;
     color: #262e33;
-  }
-
-  p {
-    line-height: 25px;
-    font-size: 14px;
   }
 
   h1 {

--- a/app/_assets/stylesheets/variables.less
+++ b/app/_assets/stylesheets/variables.less
@@ -10,6 +10,7 @@
 @family-whitney: 'Whitney A', 'Whitney B', @family-default;
 @family-whitney-ss: 'Whitney SSm A', 'Whitney SSm B', @family-default;
 @family-whitney-ss-sc: 'Whitney SSm SmallCaps A', 'Whitney SSm SmallCaps B', @family-default;
+@family-code: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 // Colors
 // -------------------------


### PR DESCRIPTION
I wonder why it has so much padding on the sides. Also the font seems smaller/out of sync with our text font. For now I only fixed the padding of `<code>` elements in `<p>` but I actually don't see a reason to have such a big padding everywhere.

Before/After of an endpoint description (same padding for background but nicer font imho...)

![before-after](https://cloud.githubusercontent.com/assets/1125431/7244230/ae689db8-e7d8-11e4-9981-c5057ccd0ccd.png)

Before/After of some text with inline `<code>` (smaller padding on the side because... and the font does not feel smaller like the old one on the left)

![before-after](https://cloud.githubusercontent.com/assets/1125431/7244248/147210da-e7d9-11e4-8e04-21acf76eb030.png)
