### PR TITLE
[feature] configuration reference

### DIFF
--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -33,6 +33,13 @@ header_caption: Learn how Kong empowers your APIs
     </nav>
 
     <nav>
+      <h5>Configuration</h5>
+      <ul>
+        <li><a href="/docs/{{page.kong_version}}/configuration">Configuration reference</a></li>
+      </ul>
+    </nav>
+
+    <nav>
       <h5>CLI Reference</h5>
       <ul>
         <li>

--- a/app/docs/0.1.1beta-2/cli.md
+++ b/app/docs/0.1.1beta-2/cli.md
@@ -8,7 +8,7 @@ Kong comes with a ***CLI*** *(Command Line Interface)* which provides you with a
 
 Almost every command requires access to your configuration file in order to be aware of where the NGINX working directory is located (known as the *prefix path* for those familiar with NGINX) referenced as `nginx_working_dir` in the Kong configuration file.
 
-**Note:** If you haven't already, we recommend you read the [configuration guide][configuration-guide].
+**Note:** If you haven't already, we recommend you read the [configuration reference][configuration-reference].
 
 ---
 
@@ -125,5 +125,5 @@ $ kong reload [parameters]
 
 Kong Configuration File
 
-[configuration-guide]: /docs/{{page.kong_version}}/configuration
+[configuration-reference]: /docs/{{page.kong_version}}/configuration
 [nginx-signals]: http://nginx.org/en/docs/control.html

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -77,7 +77,7 @@ nginx_working_dir: /usr/local/kong/
 
 
 
-A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during every request. That is to determine if the plugin needs to be executed for that particular request. Removing plugins you don't use from this list will lighten your Kong instance.
+A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during each request to determine whether the plugin should be executed. Removing plugins from this list will reduce load on your Kong instance.
 
 **Default:**
 

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -6,7 +6,7 @@ title: Configuration Reference
 
 Kong is extremely flexible and bends to your needs due to its pluggable architecture. It is also very customizable down to its configuration, allowing it to best fit your needs. From the ports it listens on, the database you want it to use, down to the underlying NGINX configuration, learn how to sharp your instance so it performs best.
 
-### 1. Where to put my configuration file?
+### 1. Where to put your configuration file?
 
 1. When using Kong, you can specify a configuration from any command with the `-c` argument. See the [CLI reference][cli-reference] for more informations.
 2. If no configuration file was manually given to Kong, it will always look for a configuration file located at `/etc/kong/kong.yml`.

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -111,7 +111,7 @@ send_anonymous_reports: true
 
 A dictionary of databases Kong can connect to, and their respective properties.
 
-Currently, Kong only supports [Cassandra v2.1.3](http://cassandra.apache.org/) as a database.
+Currently, Kong only supports [Cassandra v{{site.data.kong_latest.dependencies.cassandra}}](http://cassandra.apache.org/) as a database.
 
   **`databases_available.*.properties`**
 

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -28,7 +28,7 @@ They are all **required**.
 - [**send_anonymous_reports**](#send_anonymous_reports)
 - [**databases_available**](#databases_available)
 - [**database**](#database)
-- [**database_cache_expiration**](#database_cache_expiration)
+- [**cache.expiration**](#cache.expiration)
 - [**nginx**](#nginx)
 - [**nginx_plus_status**](#nginx_plus_status)
 

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -146,7 +146,8 @@ database: cassandra
 
 ### `cache.expiration`
 
-A value specifying (in seconds) how long Kong will keep database entities in memory. Setting this to a high value will cause Kong to avoid making regular queries to the database in order to retrieve an API's target URL.
+A value specifying (in seconds) how long Kong will keep database entities in memory. Setting this to a high value will cause Kong to avoid making multiple queries to the database in order to retrieve an API's target URL. However, this also means you may be required to wait a while before the
+cached value is flushed and reflects any potential changes made during that time.
 
 **Default:**
 

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -28,7 +28,7 @@ They are all **required**.
 - [**send_anonymous_reports**](#send_anonymous_reports)
 - [**databases_available**](#databases_available)
 - [**database**](#database)
-- [**cache.expiration**](#cache.expiration)
+- [**database_cache_expiration**](#database_cache_expiration)
 - [**nginx**](#nginx)
 - [**nginx_plus_status**](#nginx_plus_status)
 
@@ -144,7 +144,7 @@ database: cassandra
 
 ---
 
-### `cache.expiration`
+### `database_cache_expiration`
 
 A value specifying (in seconds) how long Kong will keep database entities in memory. Setting this to a high value will cause Kong to avoid making multiple queries to the database in order to retrieve an API's target URL. However, this also means you may be required to wait a while before the
 cached value is flushed and reflects any potential changes made during that time.
@@ -152,8 +152,7 @@ cached value is flushed and reflects any potential changes made during that time
 **Default:**
 
 ```yaml
-cache:
-  expiration: 5 # in seconds
+database_cache_expiration: 5 # in seconds
 ```
 
 ---

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -25,6 +25,7 @@ This reference describes every property defined in a typical configuration file 
 - [**send_anonymous_reports**](#send_anonymous_reports)
 - [**databases_available**](#databases_available)
 - [**database**](#database)
+- [**database_cache_expiration**](#database_cache_expiration)
 - [**nginx**](#nginx)
 - [**nginx_plus_status**](#nginx_plus_status)
 
@@ -107,10 +108,6 @@ A dictionary of databases Kong can connect to. The key is the name of the databa
 
   A dictionary of properties needed for Kong to connect to a given database.
 
-  **`databases_available.*.cache_expiration`**
-
-  A value specifying in seconds how much time Kong will keep a cache of the database entities into memory. For example, setting this to a high value will avoid Kong to make regular queries to the database in order to retrieve a given API's target URL.
-
 **Note:** Currently, Kong only supports [Cassandra v2.1.3](http://cassandra.apache.org/).
 
 **Default:**
@@ -124,7 +121,6 @@ databases_available:
       timeout: 1000
       keyspace: kong
       keepalive: 60000
-    cache_expiration: 5
 ```
 
 ---
@@ -138,6 +134,12 @@ The desired database to use for this Kong instance as a string, matching one of 
 ```yaml
 database: cassandra
 ```
+
+---
+
+#### `database_cache_expiration`
+
+A value specifying in seconds how much time Kong will keep a cache of the database entities into memory. For example, setting this to a high value will avoid Kong to make regular queries to the database in order to retrieve a given API's target URL.
 
 ---
 

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -26,6 +26,7 @@ This reference describes every property defined in a typical configuration file 
 - [**databases_available**](#databases_available)
 - [**database**](#database)
 - [**nginx**](#nginx)
+- [**nginx_plus_status**](#nginx_plus_status)
 
 ---
 
@@ -274,5 +275,11 @@ nginx: |
     }
   }
 ```
+
+---
+
+#### `nginx_plus_status`
+
+TODO
 
 [cli-reference]: /docs/{{page.kong_version}}/cli

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -16,6 +16,17 @@ Kong is extremely flexible and bends to your needs due to its pluggable architec
 
 This reference describes every property defined in a typical configuration file and their default values. They are all **required**.
 
+**Summary:**
+
+- [**plugins_available**](#plugins_available)
+- [**nginx_working_dir**](#nginx_working_dir)
+- [**proxy_port**](#proxy_port)
+- [**admin_api_port**](#admin_api_port)
+- [**databases_available**](#databases_available)
+- [**database**](#database)
+- [**send_anonymous_reports**](#send_anonymous_reports)
+- [**nginx**](#nginx)
+
 #### `plugins_available`
 
 A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during every request. That is to determine if the plugin needs to be executed for that particular request. Removing plugins you don't use from this list will lighten your Kong instance.

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -1,5 +1,265 @@
 ---
-title: Configuration Guide
+title: Configuration Reference
 ---
 
-Configuration Guide
+# Configuration Reference
+
+Kong is extremely flexible and bends to your needs due to its pluggable architecture. It is also very customizable down to its configuration, allowing it to best fit your needs. From the ports it listens on, the database you want it to use, down to the underlying NGINX configuration, learn how to sharp your instance so it performs best.
+
+### 1. Where to put my configuration file?
+
+1. When using Kong, you can specify a configuration from any command with the `-c` argument. See the [CLI reference][cli-reference] for more informations.
+2. If no configuration file was manually given to Kong, it will always look for a configuration file located at `/etc/kong/kong.yml`.
+3. If no configuration file is present there, Kong will load a default configuration from its Luarocks install path.
+
+### 2. Properties reference
+
+This reference describes every property defined in `kong.yml` and their default values.
+
+#### `plugins_available`
+
+A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during every request. That is to determine if the plugin needs to be executed for that particular request. Removing plugins you don't use from this list will lighten your Kong instance.
+
+**Default:**
+
+```yaml
+plugins_available:
+  - keyauth
+  - basicauth
+  - ratelimiting
+  - tcplog
+  - udplog
+  - filelog
+  - request_transformer
+```
+
+---
+
+#### `nginx_working_dir`
+
+Similar to the NGINX `--prefix` option, it defines a directory that will contain server files, such as access and error logs, or the Kong pid file.
+
+**Default:**
+
+```yaml
+nginx_working_dir: /usr/local/kong/
+```
+
+---
+
+#### `proxy_port`
+
+Port on which Kong will proxy requests. This is the port you want your consumers to make requests on.
+
+**Default:**
+
+```yaml
+proxy_port: 8000
+```
+
+---
+
+#### `admin_api_port`
+
+Port on which the [admin RESTful API](/docs/{{page.kong_version}}/admin-api/) will listen.
+
+**Note:** This port is used to operate Kong, you should keep it private and/or firewalled.
+
+**Default:**
+
+```yaml
+admin_api_port: 8001
+```
+
+---
+
+#### `databases_available`
+
+A dictionary of databases Kong can connect to. The key is the name of the database, values will be the necessary properties for Kong to connect to it.
+
+  **`databases_available.*.properties`**
+
+  A dictionary of properties needed for Kong to connect to a given database.
+
+  **`databases_available.*.cache_expiration`**
+
+  A value specifying in seconds how much time Kong will keep a cache of the database entities into memory. For example, setting this to a high value will avoid Kong to make regular queries to the database in order to retrieve a given API's target URL.
+
+**Note:** Currently, Kong only supports [Cassandra v2.1.3](http://cassandra.apache.org/).
+
+**Default:**
+
+```yaml
+databases_available:
+  cassandra:
+    properties:
+      hosts: "localhost"
+      port: 9042
+      timeout: 1000
+      keyspace: kong
+      keepalive: 60000
+    cache_expiration: 5
+```
+
+---
+
+#### `database`
+
+The desired database to use for this Kong instance as a string, matching one of the databases listed in `databases_available`.
+
+**Default:**
+
+```yaml
+database: cassandra
+```
+
+---
+
+#### `send_anonymous_reports`
+
+If set to `true`, Kong will send anonymous error reports to Mashape. This helps Mashape maintaining and improving Kong.
+
+**Default:**
+
+```yaml
+send_anonymous_reports: true
+```
+
+---
+
+#### `nginx`
+
+The NGINX configuration (usually known as `nginx.conf`) that will be used for this instance.
+
+**Note:** While it is recommended not to drastically change this configuration to prevent Konf from malfunctioning, you can still edit this configuration to your needs, to a certain extent.
+
+**Default:**
+
+```yaml
+nginx: |
+  worker_processes auto;
+  error_log logs/error.log info;
+  daemon on;
+
+  # Set "worker_rlimit_nofile" to a high value
+  # worker_rlimit_nofile 65536;
+
+  env KONG_CONF;
+
+  events {
+    # Set "worker_connections" to a high value
+    worker_connections 1024;
+  }
+
+  http {
+    resolver 8.8.8.8;
+    charset UTF-8;
+
+    access_log logs/access.log;
+    access_log on;
+
+    # Timeouts
+    keepalive_timeout 60s;
+    client_header_timeout 60s;
+    client_body_timeout 60s;
+    send_timeout 60s;
+
+    # Proxy Settings
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
+    proxy_ssl_server_name on;
+
+    # IP Address
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_recursive on;
+
+    # Other Settings
+    client_max_body_size 128m;
+    underscores_in_headers on;
+    reset_timedout_connection on;
+    tcp_nopush on;
+
+    ################################################
+    #  The following code is required to run Kong  #
+    # Please be careful if you'd like to change it #
+    ################################################
+
+    # Lua Settings
+    lua_package_path ';;';
+    lua_code_cache on;
+    lua_max_running_timers 4096;
+    lua_max_pending_timers 16384;
+    lua_shared_dict cache 512m;
+    lua_socket_log_errors off;
+
+    init_by_lua '
+      kong = require "kong"
+      local status, err = pcall(kong.init)
+      if not status then
+        ngx.log(ngx.ERR, "Startup error: "..err)
+        os.exit(1)
+      end
+    ';
+
+    server {
+      listen {{proxy_port}};
+
+      location / {
+        default_type 'text/plain';
+
+        # This property will be used later by proxy_pass
+        set $backend_url nil;
+
+        # Authenticate the user and load the API info
+        access_by_lua 'kong.exec_plugins_access()';
+
+        # Proxy the request
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass $backend_url;
+
+        # Add additional response headers
+        header_filter_by_lua 'kong.exec_plugins_header_filter()';
+
+        # Change the response body
+        body_filter_by_lua 'kong.exec_plugins_body_filter()';
+
+        # Log the request
+        log_by_lua 'kong.exec_plugins_log()';
+      }
+
+      location /robots.txt {
+        return 200 'User-agent: *\nDisallow: /';
+      }
+
+      error_page 500 /500.html;
+      location = /500.html {
+        internal;
+        content_by_lua '
+          local utils = require "kong.tools.utils"
+          utils.show_error(ngx.status, "Oops, an unexpected error occurred!")
+        ';
+      }
+    }
+
+    server {
+      listen {{admin_api_port}};
+
+      location / {
+        default_type application/json;
+        content_by_lua 'require("lapis").serve("kong.api.app")';
+      }
+
+      location /robots.txt {
+        return 200 'User-agent: *\nDisallow: /';
+      }
+
+      # Do not remove, additional configuration placeholder for some plugins
+      # {{additional_configuration}}
+    }
+  }
+```
+
+[cli-reference]: /docs/{{page.kong_version}}/cli

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -4,19 +4,22 @@ title: Configuration Reference
 
 # Configuration Reference
 
-Kong is extremely flexible and bends to your needs due to its pluggable architecture. It is also very customizable down to its configuration, allowing it to best fit your needs. From the ports it listens on, the database you want it to use, down to the underlying NGINX configuration, learn how to sharp your instance so it performs best.
+The Kong configuration file is a [YAML][yaml] file that can be specified when using Kong through the [CLI][cli-reference]. This file allows you
+to configure and customize Kong to your needs. From the ports it uses, the database it conncts to, and even the internal NGINX server itself.
 
-### 1. Where to put your configuration file?
+## Where should I place my configuration file?
 
-1. When using Kong, you can specify a configuration from any command with the `-c` argument. See the [CLI reference][cli-reference] for more informations.
-2. If no configuration file was manually given to Kong, it will always look for a configuration located at `/etc/kong/kong.yml`.
-3. If no file is present there, Kong will load a default configuration from its Luarocks install path.
+When using Kong, you can specify the location of your configuration file from any command using the `-c` argument. See the [CLI reference][cli-reference] for more information.
 
-### 2. Properties reference
+However, when no configuration file is passed to Kong, it will look under `/etc/kong/kong.yml` for a fallback configuration file. Should no file be present in this location, Kong will then load a default configuration from its Luarocks install path.
 
-This reference describes every property defined in a typical configuration file and their default values. They are all **required**.
+## Property Reference
 
-**Summary:**
+This reference describes every property defined in a typical configuration file and their default values.
+
+They are all **required**.
+
+### Summary
 
 - [**proxy_port**](#proxy_port)
 - [**admin_api_port**](#admin_api_port)
@@ -31,9 +34,9 @@ This reference describes every property defined in a typical configuration file 
 
 ---
 
-#### `proxy_port`
+### `proxy_port`
 
-Port on which Kong will proxy requests. This is the port you want your consumers to make requests on.
+Port which Kong proxies requests through, developers using your API will make requests against this port.
 
 **Default:**
 
@@ -43,11 +46,12 @@ proxy_port: 8000
 
 ---
 
-#### `admin_api_port`
+### `admin_api_port`
 
-Port on which the [admin RESTful API](/docs/{{page.kong_version}}/admin-api/) will listen.
+Port which the [RESTful Admin API](/docs/{{page.kong_version}}/admin-api/) is served through.
 
-**Note:** This port is used to operate Kong, you should keep it private and/or firewalled.
+**Note:** This port is used to manage your Kong instances, therefore it should be placed behind a firewall
+or closed off network to ensure security.
 
 **Default:**
 
@@ -57,7 +61,7 @@ admin_api_port: 8001
 
 ---
 
-#### `nginx_working_dir`
+### `nginx_working_dir`
 
 Similar to the NGINX `--prefix` option, it defines a directory that will contain server files, such as access and error logs, or the Kong pid file.
 
@@ -69,7 +73,9 @@ nginx_working_dir: /usr/local/kong/
 
 ---
 
-#### `plugins_available`
+### `plugins_available`
+
+
 
 A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during every request. That is to determine if the plugin needs to be executed for that particular request. Removing plugins you don't use from this list will lighten your Kong instance.
 
@@ -84,11 +90,12 @@ plugins_available:
   - udplog
   - filelog
   - request_transformer
+  - cors
 ```
 
 ---
 
-#### `send_anonymous_reports`
+### `send_anonymous_reports`
 
 If set to `true`, Kong will send anonymous error reports to Mashape. This helps Mashape maintaining and improving Kong.
 
@@ -100,15 +107,15 @@ send_anonymous_reports: true
 
 ---
 
-#### `databases_available`
+### `databases_available.*`
 
-A dictionary of databases Kong can connect to. The key is the name of the database, values will be the necessary properties for Kong to connect to it.
+A dictionary of databases Kong can connect to, and their respective properties.
+
+Currently, Kong only supports [Cassandra v2.1.3](http://cassandra.apache.org/) as a database.
 
   **`databases_available.*.properties`**
 
-  A dictionary of properties needed for Kong to connect to a given database.
-
-**Note:** Currently, Kong only supports [Cassandra v2.1.3](http://cassandra.apache.org/).
+  A dictionary of properties needed for Kong to connect to a given database (where `.*` is the name of the database).
 
 **Default:**
 
@@ -125,9 +132,9 @@ databases_available:
 
 ---
 
-#### `database`
+### `database`
 
-The desired database to use for this Kong instance as a string, matching one of the databases listed in `databases_available`.
+The desired database to use for this Kong instance as a string, matching one of the databases defined under [`databases_available`](#databases_available).
 
 **Default:**
 
@@ -137,17 +144,17 @@ database: cassandra
 
 ---
 
-#### `database_cache_expiration`
+### `database_cache_expiration`
 
 A value specifying in seconds how much time Kong will keep a cache of the database entities into memory. For example, setting this to a high value will avoid Kong to make regular queries to the database in order to retrieve a given API's target URL.
 
 ---
 
-#### `nginx`
+### `nginx`
 
-The NGINX configuration (usually known as `nginx.conf`) that will be used for this instance.
+The NGINX configuration (or `nginx.conf`) that will be used for this instance.
 
-**Note:** While it is recommended not to drastically change this configuration to prevent Konf from malfunctioning, you can still edit this configuration to your needs, to a certain extent.
+**Warning:** Modifying the NGINX configuration can lead to unexpected results, edit the configuration only if you are confident about doing so.
 
 **Default:**
 
@@ -280,8 +287,17 @@ nginx: |
 
 ---
 
-#### `nginx_plus_status`
+### `nginx_plus_status`
 
-TODO
+Enables live server activity monitoring of NGINX Plus plugin that provides key load and performance server metrics.
+Please see the [NGINX Plus][nginx-plus] plugin page for more information.
 
+**Default**
+
+```yaml
+nginx_plus_status: false
+```
+
+[nginx-plus]: /plugins/nginx-plus-monitoring/
 [cli-reference]: /docs/{{page.kong_version}}/cli
+[yaml]: http://yaml.org

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -18,43 +18,14 @@ This reference describes every property defined in a typical configuration file 
 
 **Summary:**
 
-- [**plugins_available**](#plugins_available)
-- [**nginx_working_dir**](#nginx_working_dir)
 - [**proxy_port**](#proxy_port)
 - [**admin_api_port**](#admin_api_port)
+- [**nginx_working_dir**](#nginx_working_dir)
+- [**plugins_available**](#plugins_available)
+- [**send_anonymous_reports**](#send_anonymous_reports)
 - [**databases_available**](#databases_available)
 - [**database**](#database)
-- [**send_anonymous_reports**](#send_anonymous_reports)
 - [**nginx**](#nginx)
-
-#### `plugins_available`
-
-A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during every request. That is to determine if the plugin needs to be executed for that particular request. Removing plugins you don't use from this list will lighten your Kong instance.
-
-**Default:**
-
-```yaml
-plugins_available:
-  - keyauth
-  - basicauth
-  - ratelimiting
-  - tcplog
-  - udplog
-  - filelog
-  - request_transformer
-```
-
----
-
-#### `nginx_working_dir`
-
-Similar to the NGINX `--prefix` option, it defines a directory that will contain server files, such as access and error logs, or the Kong pid file.
-
-**Default:**
-
-```yaml
-nginx_working_dir: /usr/local/kong/
-```
 
 ---
 
@@ -80,6 +51,49 @@ Port on which the [admin RESTful API](/docs/{{page.kong_version}}/admin-api/) wi
 
 ```yaml
 admin_api_port: 8001
+```
+
+---
+
+#### `nginx_working_dir`
+
+Similar to the NGINX `--prefix` option, it defines a directory that will contain server files, such as access and error logs, or the Kong pid file.
+
+**Default:**
+
+```yaml
+nginx_working_dir: /usr/local/kong/
+```
+
+---
+
+#### `plugins_available`
+
+A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during every request. That is to determine if the plugin needs to be executed for that particular request. Removing plugins you don't use from this list will lighten your Kong instance.
+
+**Default:**
+
+```yaml
+plugins_available:
+  - keyauth
+  - basicauth
+  - ratelimiting
+  - tcplog
+  - udplog
+  - filelog
+  - request_transformer
+```
+
+---
+
+#### `send_anonymous_reports`
+
+If set to `true`, Kong will send anonymous error reports to Mashape. This helps Mashape maintaining and improving Kong.
+
+**Default:**
+
+```yaml
+send_anonymous_reports: true
 ```
 
 ---
@@ -122,18 +136,6 @@ The desired database to use for this Kong instance as a string, matching one of 
 
 ```yaml
 database: cassandra
-```
-
----
-
-#### `send_anonymous_reports`
-
-If set to `true`, Kong will send anonymous error reports to Mashape. This helps Mashape maintaining and improving Kong.
-
-**Default:**
-
-```yaml
-send_anonymous_reports: true
 ```
 
 ---

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -144,9 +144,16 @@ database: cassandra
 
 ---
 
-### `database_cache_expiration`
+### `cache.expiration`
 
-A value specifying in seconds how much time Kong will keep a cache of the database entities into memory. For example, setting this to a high value will avoid Kong to make regular queries to the database in order to retrieve a given API's target URL.
+A value specifying (in seconds) how long Kong will keep database entities in memory. Setting this to a high value will cause Kong to avoid making regular queries to the database in order to retrieve an API's target URL.
+
+**Default:**
+
+```yaml
+cache:
+  expiration: 5 # in seconds
+```
 
 ---
 

--- a/app/docs/0.1.1beta-2/configuration.md
+++ b/app/docs/0.1.1beta-2/configuration.md
@@ -9,12 +9,12 @@ Kong is extremely flexible and bends to your needs due to its pluggable architec
 ### 1. Where to put your configuration file?
 
 1. When using Kong, you can specify a configuration from any command with the `-c` argument. See the [CLI reference][cli-reference] for more informations.
-2. If no configuration file was manually given to Kong, it will always look for a configuration file located at `/etc/kong/kong.yml`.
-3. If no configuration file is present there, Kong will load a default configuration from its Luarocks install path.
+2. If no configuration file was manually given to Kong, it will always look for a configuration located at `/etc/kong/kong.yml`.
+3. If no file is present there, Kong will load a default configuration from its Luarocks install path.
 
 ### 2. Properties reference
 
-This reference describes every property defined in `kong.yml` and their default values.
+This reference describes every property defined in a typical configuration file and their default values. They are all **required**.
 
 #### `plugins_available`
 

--- a/app/docs/0.1.1beta-2/getting-started/quickstart.md
+++ b/app/docs/0.1.1beta-2/getting-started/quickstart.md
@@ -10,7 +10,7 @@ title: 5-minute Quickstart
 
 In this section, you'll learn how to manage your Kong instance. First we'll have you start Kong giving you access to the RESTful interface to manage your APIs, consumers, and more. Data sent through the RESTful interface is stored in your Cassandra instance or cluster, meaning you **must** have Cassandra running **before** starting Kong.
 
-**Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration guide][configuration] before starting.
+**Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
 1. ### Start Kong.
 
@@ -60,5 +60,5 @@ To begin, go to [Adding your API &rsaquo;][adding-your-api]
 [install]: /download
 [migrations]: /docs/{{page.kong_version}}/migrations
 [quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart
-[configuration]: /download
+[configuration]: /docs/{{page.kong_version}}/configuration
 [adding-your-api]: /docs/{{page.kong_version}}/getting-started/adding-your-api


### PR DESCRIPTION
Here is the Kong configuration reference. I tried to be as inspired as possible for the intro text but well, it wasn't that efficient...

Also I am not sure about the side menu in `docs.html`.

@Nijikokun Please review, rephrase, reword :)

@thefosk I still don't know what `nginx_plus_status` really does. Could you please update the PR or explain here.

**Depends on Mashape/kong#162 being merged.**