### PR TITLE
[docs] update download section to the new Docker images

### DIFF
--- a/app/_includes/pages/download/docker.md
+++ b/app/_includes/pages/download/docker.md
@@ -1,15 +1,19 @@
 ### Docker
 
+Details about how to use Kong in Docker can be found on the Dockerhub repo hosting the image: [mashape/kong](https://registry.hub.docker.com/u/mashape/kong/).
+
+Here is a quick setup linking Kong to a Cassandra container:
+
 1. **Start Cassandra:**
 
 	```bash
-	$ docker run -p 9042:9042 -d --name cassandra mashape/docker-cassandra
+	$ docker run -p 9042:9042 -d --name cassandra mashape/cassandra
 	```
 
 2. **Start Kong:**
 
     ```bash
-    $ docker run -p 8000:8000 -p 8001:8001 -d --name kong --link cassandra:cassandra mashape/docker-kong:{{site.data.kong_latest.version}}
+    $ docker run -p 8000:8000 -p 8001:8001 -d --name kong --link cassandra:cassandra mashape/kong
     ```
 
 3. **Kong is running:**


### PR DESCRIPTION
This PR proposes to switch to the new Dockerhub repos, as already discussed internally:

- [mashape/cassandra](https://registry.hub.docker.com/u/mashape/cassandra/)
- [mashape/kong](https://registry.hub.docker.com/u/mashape/kong/)

Both of them:
- have been updated (docs + Dockerfile): mashape/docker-cassandra#1 and mashape/docker-kong#3
- have a nicer README on Dockerhub that complies with most official repos

mashape/kong is trying to go as an "Official Image", [here](https://github.com/Mashape/docker-kong/issues/4) is the roadmap for that, with what is done and left to do.

Screenshot of the website update:

![screenshot 2015-05-04 22 55 55](https://cloud.githubusercontent.com/assets/1125431/7462321/d70f7416-f2b0-11e4-82ca-939cd556cf34.png)

**Once this is merged, we should remove the old Dockerhub repos [mashape/docker-kong](https://hub.docker.com/u/mashape/docker-kong/) (287 downloads, 3 stars) and [mashape/docker-cassandra](https://hub.docker.com/u/mashape/docker-cassandra/) (248 downloads, 0 stars).