### PR TITLE
[docs] 0.2.1

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -1,7 +1,20 @@
 -
-  version: 0.2.0-2
+  version: "0.2.0-2"
   dependencies:
-    lua: 5.1.5
-    luarocks: 2.2.2
-    cassandra: 2.1.5
-    openresty: 1.7.10.2
+    lua: "5.1.4"
+    luarocks: "2.2.0"
+    cassandra: "2.1.5"
+    openresty: "1.7.10.2"
+  version: "0.2.1"
+  dependencies:
+    lua: "5.1.4"
+    luarocks: "2.2.0"
+    cassandra: "2.1.5"
+    openresty: "1.7.10.2"
+  version: "0.2.1"
+  dependencies:
+    lua: "5.1.4"
+    luarocks: "2.2.2"
+    dnsmasq: "2.72"
+    cassandra: "2.1.5"
+    openresty: "1.7.10.2"

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -6,7 +6,7 @@
       <span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
     <nav id="navbar" class="navbar-nav">
       <ul>
-        <li><a href="/docs/{{site.data.kong_latest.version}}" {% if page.url contains "/docs/" %} class="active"{% endif %}>Docs</a></li>
+        <li><a href="/docs/" {% if page.url contains "/docs/" %} class="active"{% endif %}>Docs</a></li>
         <li><a href="/plugins" {% if page.url == "/plugins/" %} class="active"{% endif %}>Plugins</a></li>
         <li><a href="/community" {% if page.url == "/community/" %} class="active"{% endif %}>Community</a></li>
         <li><a href="/enterprise" {% if page.url == "/enterprise/" %} class="active"{% endif %}>Enterprise</a></li>

--- a/app/_includes/pages/download/centos.md
+++ b/app/_includes/pages/download/centos.md
@@ -4,17 +4,17 @@
 
 1. **Installation:**
 
-    For CentOS 5/RHEL5 download this package: [kong-0.2.0_2.el5.noarch.rpm](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0_2.el5.noarch.rpm) *- Recommended for Amazon Linux AMI*
+    For CentOS 5/RHEL5 download this package: [kong-{{site.data.kong_latest.version}}.el5.noarch.rpm](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el5.noarch.rpm) *- Recommended for Amazon Linux AMI*
 
-    For CentOS 6/RHEL6 download this package: [kong-0.2.0_2.el6.noarch.rpm](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0_2.el6.noarch.rpm)
+    For CentOS 6/RHEL6 download this package: [kong-{{site.data.kong_latest.version}}.el6.noarch.rpm](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el6.noarch.rpm)
 
-    For CentOS 7/RHEL7 download this package: [kong-0.2.0_2.el7.noarch.rpm](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0_2.el7.noarch.rpm)
+    For CentOS 7/RHEL7 download this package: [kong-{{site.data.kong_latest.version}}.el7.noarch.rpm](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el7.noarch.rpm)
 
     Then execute:
 
     ```bash
     $ sudo yum install epel-release
-    $ sudo yum install kong-0.2.0_2.*.noarch.rpm --nogpgcheck
+    $ sudo yum install kong-{{site.data.kong_latest.version}}.*.noarch.rpm --nogpgcheck
     ```
 
 2. **Configure Cassandra**

--- a/app/_includes/pages/download/debian.md
+++ b/app/_includes/pages/download/debian.md
@@ -4,18 +4,18 @@
 
 1. **Installation:**
 
-    For Debian 6 Squeeze download this package: [kong-0.2.0-2.squeeze_all.deb](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.squeeze_all.deb)
+    For Debian 6 Squeeze download this package: [kong-{{site.data.kong_latest.version}}.squeeze_all.deb](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.squeeze_all.deb)
 
-    For Debian 7 Wheezy download this package: [kong-0.2.0-2.wheezy_all.deb](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.wheezy_all.deb)
+    For Debian 7 Wheezy download this package: [kong-{{site.data.kong_latest.version}}.wheezy_all.deb](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.wheezy_all.deb)
 
-    For Debian 8 Jessie download this package: [kong-0.2.0-2.jessie_all.deb](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.jessie_all.deb)
+    For Debian 8 Jessie download this package: [kong-{{site.data.kong_latest.version}}.jessie_all.deb](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.jessie_all.deb)
 
     Then execute:
 
     ```bash
     $ sudo apt-get update
-    $ sudo dpkg -i kong-0.2.0-2.*.deb
-    $ sudo apt-get install -f
+    $ sudo apt-get install sudo netcat lua5.1 openssl libpcre3 dnsmasq
+    $ sudo dpkg -i kong-{{site.data.kong_latest.version}}.*.deb
     ```
 
 2. **Configure Cassandra**

--- a/app/_includes/pages/download/osx.md
+++ b/app/_includes/pages/download/osx.md
@@ -6,7 +6,7 @@
 
     *Package*
 
-    You can download a **.pkg** installer at: [kong-0.2.0-2.pkg](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.pkg). After installing the package you can skip to step 2.
+    You can download a **.pkg** installer at: [kong-{{site.data.kong_latest.version}}.pkg](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.pkg). After installing the package you can skip to step 2.
 
     **Note:** This installer is not yet signed so you will have to **right click**, select "Open" and authorize it.
 

--- a/app/_includes/pages/download/other.md
+++ b/app/_includes/pages/download/other.md
@@ -1,5 +1,6 @@
 {% capture lua_version %}{{site.data.kong_latest.dependencies.lua}}{% endcapture %}
 {% capture luarocks_version %}{{site.data.kong_latest.dependencies.luarocks}}{% endcapture %}
+{% capture dnsmasq_version %}{{site.data.kong_latest.dependencies.dnsmasq}}{% endcapture %}
 {% capture cassandra_version %}{{site.data.kong_latest.dependencies.cassandra}}{% endcapture %}
 {% capture openresty_version %}{{site.data.kong_latest.dependencies.openresty}}{% endcapture %}
 
@@ -11,6 +12,8 @@
     Install [Lua v{{lua_version}}](http://www.lua.org/versions.html#5.1)
 
     Install [Luarocks v{{luarocks_version}}](https://github.com/keplerproject/luarocks/wiki/Download)
+
+    Install [Dnsmasq v{{dnsmasq_version}}](http://www.thekelleys.org.uk/dnsmasq/)
 
     Install [OpenResty v{{openresty_version}}](http://openresty.com/#Installation), with the following `configure` options:
 

--- a/app/_includes/pages/download/ubuntu.md
+++ b/app/_includes/pages/download/ubuntu.md
@@ -4,18 +4,18 @@
 
 1. **Installation:**
 
-    For Ubuntu 12.04 Precise download this package: [kong-0.2.0-2.precise_all.deb](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.precise_all.deb)
+    For Ubuntu 12.04 Precise download this package: [kong-{{site.data.kong_latest.version}}.precise_all.deb](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.precise_all.deb)
 
-    For Ubuntu 14.04 Trusty download this package: [kong-0.2.0-2.trusty_all.deb](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.trusty_all.deb)
+    For Ubuntu 14.04 Trusty download this package: [kong-{{site.data.kong_latest.version}}.trusty_all.deb](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.trusty_all.deb)
 
-    For Ubuntu 15.04 Vivid Vervet download this package: [kong-0.2.0-2.vivid_all.deb](https://github.com/Mashape/kong/releases/download/0.2.0-2/kong-0.2.0-2.vivid_all.deb)
+    For Ubuntu 15.04 Vivid Vervet download this package: [kong-{{site.data.kong_latest.version}}.vivid_all.deb](https://github.com/Mashape/kong/releases/download/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.vivid_all.deb)
 
     Then execute:
 
     ```bash
     $ sudo apt-get update
-    $ sudo dpkg -i kong-0.2.0-2.*.deb
-    $ sudo apt-get install -f
+    $ sudo apt-get install sudo netcat lua5.1 openssl libpcre3 dnsmasq
+    $ sudo dpkg -i kong-{{site.data.kong_latest.version}}.*.deb
     ```
 
 2. **Configure Cassandra**

--- a/app/docs/0.2.1/about/how.md
+++ b/app/docs/0.2.1/about/how.md
@@ -1,0 +1,28 @@
+---
+title: How does it work?
+alias: /docs/latest/about/how
+---
+
+# How does it work?
+
+Kong is made of two different components that are easy to set up and scale independently:
+
+* The **Kong Server**, based on a modified version of the widely adopted **NGINX** server, processes API requests.
+* **Apache Cassandra**, a highly scalable Datastore for storing operational data, is used by major companies like Netflix, Comcast and Facebook.
+
+Kong needs to have both these components set up and operational. A typical Kong installation can be summed up with the following picture:
+
+![](/assets/images/docs/kong-detailed.png)
+
+Don't worry if you are not experienced with these technologies, Kong works out of the box and you or your engineering team will be able to set it up quickly without issues. Feel free to contact us for any technical question.
+
+## Kong Server
+
+The Kong Server, built on top of **NGINX**, is the server that will actually process the API requests and execute the configured plugins to provide additional functionalities to the underlying APIs before proxying the request to the final destination.
+
+The Proxy Server listens on two ports, that by default are:
+
+* Port `8000`, that will be used to process the API requests.
+* Port `8001`, called **Admin API port**, provides the Kong's RESTful Admin API that you can use to operate Kong, and should be private and firewalled.
+
+You can use the **admin port** to configure Kong, create new users, installing or removing plugins, and a handful of other operations. Since you will be using a RESTful API to operate Kong, it is also extremely easy to integrate Kong with existing systems.

--- a/app/docs/0.2.1/about/plugins.md
+++ b/app/docs/0.2.1/about/plugins.md
@@ -1,0 +1,12 @@
+---
+title: What are plugins?
+alias: /docs/latest/about/plugins
+---
+
+# What are plugins?
+
+Plugins are one of the most important features of Kong. All the functionalities provided by Kong are done so by easy to use **plugins**. Authentication, rate-limiting, logging and many more. Plugins can be installed and configured through Kong's REStful Admin API.
+
+From a technical perspective, a plugin is [Lua](http://www.lua.org/) code that's being executed during the life-cycle of an API request and response. Through plugins, Kong can be extended to fit any custom need or integration challenge. For example, if you need to integrate the API user authentication with a third-party enterprise security system, that would be implemented in a dedicated plugin that is run on every API request.
+
+Feel free to explore the [available plugins](/plugins) or learn how to [enable plugins](/docs/{{page.kong_version}}/getting-started/enabling-plugins) with the [plugin configuration API](/docs/{{page.kong_version}}/admin-api/#plugin-configuration-object).

--- a/app/docs/0.2.1/about/scaling.md
+++ b/app/docs/0.2.1/about/scaling.md
@@ -1,0 +1,20 @@
+---
+title: How does it scale?
+alias: /docs/latest/about/scaling
+---
+
+# How does it scale?
+
+When it comes down to scaling Kong, you need to keep in mind that you will need to scale both the API server and the underlying datastore (Apache Cassandra).
+
+## Kong Server
+
+Scaling the Kong Server up or down is actually very easy. Each server is stateless meaning you can add or remove as many nodes under the load balancer as you want.
+
+Be aware that terminating a node might interrupt any ongoing HTTP requests on that server, so you want to make sure that before terminating the node all HTTP requests have been processed.
+
+## Cassandra
+
+Scaling Cassandra shouldn't be required often, and usually a 2-node setup per datacenter is going to be enough for most of your needs, but of course if your load is expected to be very high then you may want to consider configuring your nodes properly and prepare the cluster to be scaled to handle more requests.
+
+The easy part is that Cassandra can be scaled up and down just by adding or removing nodes on the cluster, and the system will take care of re-balancing the data in the cluster.

--- a/app/docs/0.2.1/about/what.md
+++ b/app/docs/0.2.1/about/what.md
@@ -1,0 +1,26 @@
+---
+title: What is Kong?
+alias: /docs/latest/about/what
+---
+
+# What is Kong?
+
+Kong is a scalable, open source **API Layer** *(also known as a API Gateway, or API Middleware)*. Kong runs in front of any RESTful API and is extended through [Plugins](/docs/{{page.kong_version}}/about/plugins), which provide [extra functionalities and services](/plugins) beyond the core platform.
+
+Mashape, the worlds largest API marketplace, over the past several years has been powered by Kong. Delivering reliable and secure service to the 140,000 active developers in the Mashape community.
+
+* **Scalable**: Kong easily scales horizontally by simply adding more machines, meaning your platform can handle virtually any load while keeping latency low.
+
+* **Modular**: Kong can be extended by adding new plugins, which are easily configured through an RESTful Admin API.
+
+* **Runs on any infrastructure**: Kong runs anywhere. You can deploy Kong in the cloud or on-premise environments, including single or multi-datacenter setups and for public, private or invite-only APIs.
+
+Kong is built on top of reliable technologies like **NGINX** and **Apache Cassandra**, and provides you with an easy to use [RESTful API](/docs/{{page.kong_version}}/admin-api) to operate and configure the system.
+
+## Request Workflow
+
+To better understand the system, this is a typical request workflow of an API that uses Kong:
+
+![](/assets/images/docs/kong-simple.png)
+
+Once Kong is running, every request being made to the API will hit Kong first, and then it will be proxied to the final API. In between requests and responses Kong will execute any plugin that you decided to install, empowering your APIs. Kong is effectively going to be the entry point for every API request.

--- a/app/docs/0.2.1/admin-api.md
+++ b/app/docs/0.2.1/admin-api.md
@@ -1,0 +1,569 @@
+---
+title: Admin API
+alias: /docs/latest/admin-api
+---
+
+# Kong Admin API
+
+Kong comes with an **internal** RESTful API for administration purposes. API commands can be run on any node in the cluster, and Kong will keep the configuration consistent across all nodes.
+
+- The RESTful Admin API listens on port `8001`.
+
+---
+
+## API Object
+
+The API object describes an API that's being exposed by Kong. In order to do that Kong needs to know what is going to be the DNS address that will be pointing to the API, and what is the final target URL of the API where the requests will be proxied. Kong can serve more than one API domain.
+
+```json
+{
+    "name": "Mockbin",
+    "public_dns": "mockbin.com",
+    "target_url": "https://mockbin.com"
+}
+```
+
+---
+
+### Add API
+
+#### Endpoint
+
+<div class="endpoint post">/apis/</div>
+
+#### Request Form Parameters
+
+Attributes | Description
+ ---:| ---
+`name`<br>*optional* | API name. If none is specified, will default to the `public_dns`.
+`public_dns` | The public DNS address that points to your API. For example, `mockbin.com`.
+`target_url` | The base target URL that points to your API server, this URL will be used for proxying requests. For example, `https://mockbin.com`.
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "name": "Mockbin",
+    "public_dns": "mockbin.com",
+    "target_url": "http://mockbin.com",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Retrieve API
+
+#### Endpoint
+
+<div class="endpoint get">/apis/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the API to be retrieved
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "name": "Mockbin",
+    "public_dns": "mockbin.com",
+    "target_url": "https://mockbin.com",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List APIs
+
+#### Endpoint
+
+<div class="endpoint get">/apis/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+ ---:| ---
+`id`<br>*optional* | A filter on the list based on the apis `id` field.
+`name`<br>*optional* | A filter on the list based on the apis `name` field.
+`public_dns`<br>*optional* | A filter on the list based on the apis `public_dns` field.
+`target_url`<br>*optional* | A filter on the list based on the apis `target_url` field.
+`limit`<br>*optional, default is __10__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+            "name": "Mockbin",
+            "public_dns": "mockbin.com",
+            "target_url": "https://mockbin.com",
+            "created_at": 1422386534
+        },
+        {
+            "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+            "name": "PrivateAPI",
+            "public_dns": "internal.api.com",
+            "target_url": "http://private.api.com",
+            "created_at": 1422386585
+        }
+    ],
+    "next": "http://localhost:8001/apis/?limit=10&offset=4d924084-1adb-40a5-c042-63b19db421d1",
+    "previous": "http://localhost:8001/apis/?limit=10&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update API
+
+#### Endpoint
+
+<div class="endpoint put">/apis/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the API to be updated
+
+#### Request Body
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "name": "Mockbin2",
+    "public_dns": "mockbin.com",
+    "target_url": "http://mockbin.com",
+    "created_at": 1422386534
+}
+```
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "name": "Mockbin2",
+    "public_dns": "mockbin.com",
+    "target_url": "http://mockbin.com",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Delete API
+
+#### Endpoint
+
+<div class="endpoint delete">/apis/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the API to be deleted
+
+#### Response
+
+```
+HTTP 204 NO CONTENT
+```
+
+---
+
+## Consumer Object
+
+The Consumer object represents a consumer, or a user, of an API. You can either rely on Kong as the primary datastore, or you can be map the consumer list with your database to keep consistency between Kong and your existing primary datastore.
+
+```json
+{
+    "custom_id": "abc123"
+}
+```
+
+---
+
+### Create Consumer
+
+#### Endpoint
+
+<div class="endpoint post">/consumers/</div>
+
+#### Request Form Parameters
+
+Attributes | Description
+ ---:| ---
+`username`<br>**semi-optional** | The username of the consumer. You must send either this field or `custom_id` with the request.
+`custom_id`<br>**semi-optional** | Field for storing an existing ID for the consumer, useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Retrieve Consumer
+
+#### Endpoint
+
+<div class="endpoint get">/consumers/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the consumer to be retrieved
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List Consumers
+
+#### Endpoint
+
+<div class="endpoint get">/consumers/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+ ---:| ---
+`id`<br>*optional* | A filter on the list based on the consumer `id` field.
+`custom_id`<br>*optional* | A filter on the list based on the consumer `custom_id` field.
+`username`<br>*optional* | A filter on the list based on the consumer `username` field.
+`limit`<br>*optional, default is __10__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+            "custom_id": "abc123",
+            "created_at": 1422386534
+        },
+        {
+            "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+            "custom_id": "def345",
+            "created_at": 1422386585
+        }
+    ],
+    "next": "http://localhost:8001/consumers/?limit=10&offset=4d924084-1adb-40a5-c042-63b19db421d1",
+    "previous": "http://localhost:8001/consumers/?limit=10&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update Consumer
+
+#### Endpoint
+
+<div class="endpoint put">/consumers/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the consumer to be updated
+
+#### Request Body
+
+```json
+{
+    "custom_id": "updated_abc123"
+}
+```
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "updated_abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Delete Consumer
+
+#### Endpoint
+
+<div class="endpoint delete">/consumers/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the consumer to be deleted
+
+#### Response
+
+```
+HTTP 204 NO CONTENT
+```
+
+---
+
+## Plugin Configuration Object
+
+The Plugin Configuration object represents a plugin configuration that will be executed during the HTTP request/response workflow, and it's how you can add functionalities to APIs that run behind Kong, like Authentication or Rate Limiting for example. You can find more information about how to install and what values each plugin takes by visiting the [Plugin Gallery](/plugins).
+
+When creating a Plugin Configuration on top of an API, every request made by a client will be evaluated by the plugin configuration you setup. Sometimes the Plugin Configuration needs to be tuned to different values for some specific consumers, you can do that by specifying the `consumer_id` value.
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "ratelimiting",
+    "value": {
+        "limit": 20,
+        "period": "minute"
+    },
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Create Plugin Configuration
+
+#### Endpoint
+
+<div class="endpoint post">/plugins_configurations/</div>
+
+#### Request Form Parameters
+
+Attributes | Description
+ ---:| ---
+`name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
+`api_id` | The unique identifier of the API the plugin will be enabled for.
+`consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
+`value.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "ratelimiting",
+    "value": {
+        "limit": 20,
+        "period": "minute"
+    },
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Retrieve Plugin Configuration
+
+#### Endpoint
+
+<div class="endpoint get">/plugins_configurations/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the plugin configuration to be retrieved
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "ratelimiting",
+    "value": {
+        "limit": 20,
+        "period": "minute"
+    },
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List Plugin Configurations
+
+#### Endpoint
+
+<div class="endpoint get">/plugins_configurations/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+ ---:| ---
+`id`<br>*optional* | A filter on the list based on the `id` field.
+`name`<br>*optional* | A filter on the list based on the `name` field.
+`api_id`<br>*optional* | A filter on the list based on the `api_id` field.
+`consumer_id`<br>*optional* | A filter on the list based on the `consumer_id` field.
+`limit`<br>*optional, default is __10__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+      {
+          "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+          "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+          "name": "ratelimiting",
+          "value": {
+              "limit": 20,
+              "period": "minute"
+          },
+          "created_at": 1422386534
+      },
+      {
+          "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+          "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+          "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+          "name": "ratelimiting",
+          "value": {
+              "limit": 300,
+              "period": "hour"
+          },
+          "created_at": 1422386585
+      }
+    ],
+    "next": "http://localhost:8001/plugins_configurations/?limit=10&offset=4d924084-1adb-40a5-c042-63b19db421d1",
+    "previous": "http://localhost:8001/plugins_configurations/?limit=10&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update Plugin Configuration
+
+#### Endpoint
+
+<div class="endpoint put">/plugins_configurations/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the plugin configuration to be retrieved
+
+#### Request Body
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "ratelimiting",
+    "value": {
+        "limit": 50,
+        "period": "second"
+    },
+    "created_at": 1422386534
+}
+```
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "api_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "ratelimiting",
+    "value": {
+        "limit": 50,
+        "period": "second"
+    },
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Delete Plugin Configuration
+
+#### Endpoint
+
+<div class="endpoint delete">/plugins_configurations/{id}</div>
+
+Attributes | Description
+ ---:| ---
+`id`<br>**required** | The unique identifier of the plugin configuration to be deleted
+
+#### Response
+
+```
+HTTP 204 NO CONTENT
+```
+
+[gitter-url]: https://gitter.im/Mashape/kong?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/app/docs/0.2.1/cli.md
+++ b/app/docs/0.2.1/cli.md
@@ -1,0 +1,132 @@
+---
+title: CLI Reference
+alias: /docs/latest/cli
+---
+
+# CLI Reference
+
+Kong comes with a ***CLI*** *(Command Line Interface)* which provides you with an interface to manage your Kong nodes. Each command is run in the context of a single node, since Kong has no cluster awareness yet.
+
+Almost every command requires access to your configuration file in order to be aware of where the NGINX working directory is located (known as the *prefix path* for those familiar with NGINX) referenced as `nginx_working_dir` in the Kong configuration file.
+
+**Note:** If you haven't already, we recommend you read the [configuration reference][configuration-guide].
+
+---
+
+## kong
+
+```bash
+$ kong [options] <command> [parameters]
+```
+
+**Note** For help information on a specific command use the `--help` parameter: `kong <command> --help`
+
+### Options
+
+* `--help` - Outputs help information
+* `--version` - Outputs kong version
+
+---
+
+## start
+
+Starts a Kong instance.
+
+```bash
+$ kong start [parameters]
+```
+
+### Parameters
+
+#### -c \<configuration file path>
+
+Kong Configuration File
+
+When no configuration file is provided as an argument, Kong by default will attempt to load the a configuration file at `/etc/kong/kong.yml`.
+Should no configuration file exist at that location Kong will load the default configuration stored internally.
+
+This file contains configuration for plugins, the datastore, and NGINX. You can read more about this file in the [configuration guide][configuration-guide].
+
+---
+
+## stop
+
+Terminates a Kong instance by firing the NGINX `stop` signal. This will execute a fast shutdown.
+
+```bash
+$ kong stop [parameters]
+```
+
+> For more informations regarding the NGINX signals, consult their [documentation][nginx-signals].
+
+### Parameters
+
+#### -c \<configuration file path>
+
+Kong Configuration File
+
+Passing the Kong configuration file path *allows the termination of specific instance*, should you not pass the configuration file location, the command will
+default to the configuration at `/etc/kong/kong.yml` or its internal default configuration.
+
+---
+
+## quit
+
+Gracefully stops a Kong instance by firing the NGINX `quit` signal.
+
+```bash
+$ kong quit [parameters]
+```
+
+> For more informations regarding the NGINX signals, consult their [documentation][nginx-signals].
+
+### Parameters
+
+#### -c \<configuration file path>
+
+Kong Configuration File
+
+Passing the Kong configuration file path *allows the termination of specific instance*, should you not pass the configuration file location, the command will
+default to the configuration at `/etc/kong/kong.yml` or its internal default configuration.
+
+---
+
+## restart
+
+This command sends NGINX a `stop` signal, followed by a `start` signal. If Kong was not running prior to the command, it will attempt to start it:
+
+```bash
+$ kong restart [parameters]
+```
+
+### Parameters
+
+#### -c \<configuration file path>
+
+Kong Configuration File
+
+When no configuration file is provided as an argument, Kong by default will attempt to load the a configuration file at `/etc/kong/kong.yml`.
+Should no configuration file exist at that location Kong will load the default configuration stored internally.
+
+This file contains configuration for plugins, the datastore, and NGINX. You can read more about this file in the [configuration guide][configuration-guide].
+
+---
+
+## reload
+
+Reloads the NGINX configuration at runtime and avoids potential downtime by leveraging the NGINX [reload][nginx-reload] signal.
+
+```bash
+$ kong reload [parameters]
+```
+
+### Parameters
+
+#### -c \<configuration file path>
+
+Kong Configuration File
+
+
+[configuration-guide]: /docs/{{page.kong_version}}/configuration
+[nginx-signals]: http://nginx.org/en/docs/control.html
+[nginx-reload]: http://wiki.nginx.org/CommandLine#Loading_a_New_Configuration_Using_Signals

--- a/app/docs/0.2.1/configuration.md
+++ b/app/docs/0.2.1/configuration.md
@@ -1,0 +1,378 @@
+---
+title: Configuration Reference
+alias: /docs/latest/configuration
+---
+
+# Configuration Reference
+
+The Kong configuration file is a [YAML][yaml] file that can be specified when using Kong through the [CLI][cli-reference]. This file allows you
+to configure and customize Kong to your needs. From the ports it uses, the database it conncts to, and even the internal NGINX server itself.
+
+## Where should I place my configuration file?
+
+When using Kong, you can specify the location of your configuration file from any command using the `-c` argument. See the [CLI reference][cli-reference] for more information.
+
+However, when no configuration file is passed to Kong, it will look under `/etc/kong/kong.yml` for a fallback configuration file. Should no file be present in this location, Kong will then load a default configuration from its Luarocks install path.
+
+## Property Reference
+
+This reference describes every property defined in a typical configuration file and their default values.
+
+They are all **required**.
+
+### Summary
+
+- [**proxy_port**](#proxy_port)
+- [**admin_api_port**](#admin_api_port)
+- [**dnsmasq_port**](#dnsmasq_port)
+- [**nginx_working_dir**](#nginx_working_dir)
+- [**plugins_available**](#plugins_available)
+- [**send_anonymous_reports**](#send_anonymous_reports)
+- [**databases_available**](#databases_available.*)
+- [**database**](#database)
+- [**database_cache_expiration**](#database_cache_expiration)
+- [**memory_cache_size**](#memory_cache_size)
+- [**nginx**](#nginx)
+
+---
+
+### `proxy_port`
+
+Port which Kong proxies requests through, developers using your API will make requests against this port.
+
+**Default:**
+
+```yaml
+proxy_port: 8000
+```
+
+---
+
+### `admin_api_port`
+
+Port which the [RESTful Admin API](/docs/{{page.kong_version}}/admin-api/) is served through.
+
+**Note:** This port is used to manage your Kong instances, therefore it should be placed behind a firewall
+or closed off network to ensure security.
+
+**Default:**
+
+```yaml
+admin_api_port: 8001
+```
+
+---
+
+### `dnsmasq_port`
+
+Port where [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) will listen to.
+
+**Note:** This port is used to manage properly resolve DNS addresses by the Kong instances, therefore it should be placed behind a firewall or closed off network to ensure security.
+
+**Default:**
+
+```yaml
+dnsmasq_port: 8053
+```
+
+---
+
+### `nginx_working_dir`
+
+Similar to the NGINX `--prefix` option, it defines a directory that will contain server files, such as access and error logs, or the Kong pid file.
+
+**Default:**
+
+```yaml
+nginx_working_dir: /usr/local/kong/
+```
+
+---
+
+### `plugins_available`
+
+
+
+A list of plugins installed on this node that Kong will load and try to execute during the lifetime of a request. Kong will look for a [`plugin configuration`](/docs/{{page.kong_version}}/admin-api/#plugin-object) entry for each plugin in this list during each request to determine whether the plugin should be executed. Removing plugins from this list will reduce load on your Kong instance.
+
+**Default:**
+
+```yaml
+plugins_available:
+  - keyauth
+  - basicauth
+  - ratelimiting
+  - tcplog
+  - udplog
+  - filelog
+  - request_transformer
+  - cors
+```
+
+---
+
+### `send_anonymous_reports`
+
+If set to `true`, Kong will send anonymous error reports to Mashape. This helps Mashape maintaining and improving Kong.
+
+**Default:**
+
+```yaml
+send_anonymous_reports: true
+```
+
+---
+
+### `databases_available.*`
+
+A dictionary of databases Kong can connect to, and their respective properties.
+
+Currently, Kong only supports [Cassandra v{{site.data.kong_latest.dependencies.cassandra}}](http://cassandra.apache.org/) as a database.
+
+**Default:**
+
+```yaml
+databases_available:
+  cassandra:
+    properties:
+      hosts: "localhost"
+      port: 9042
+      timeout: 1000
+      keyspace: kong
+      keepalive: 60000
+```
+
+  **`databases_available.*.properties`**
+
+  A dictionary of properties needed for Kong to connect to a given database (where `.*` is the name of the database).
+
+  **`databases_available.*.properties.hosts`**
+
+  The hosts(s) on which Kong should connect to for accessing your Cassandra cluster. Can either be a string or a list. If Kong must connect to another port than the one specified in `properties` for one of your nodes, you can override it for that particular node.
+
+  **Example:**
+
+```yaml
+properties:
+  port: 9042
+  hosts:
+    - "52.5.149.55"      # will connect on port 9042
+    - "52.5.149.56:9000" # will connect on port 9000
+```
+
+  **`databases_available.*.properties.port`**
+
+  The default port on which Kong should connect on your hosts.
+
+  **Default:**
+
+```yaml
+port: 9042
+```
+
+  **`databases_available.*.properties.timeout`**
+
+  Sets the timeout (in milliseconds) for sockets performing operations between Kong and Cassandra.
+
+  **Default:**
+
+```yaml
+timeout: 1000
+```
+
+  **`databases_available.*.properties.keyspace`**
+
+  The keyspace in which Kong operates on your cluster.
+
+  **Default:**
+
+```yaml
+keyspace: kong
+```
+
+  **`databases_available.*.properties.keepalive`**
+
+  The time (in milliseconds) during which Cassandra sockets can be reused by Kong before being closed.
+
+  **Default:**
+
+```yaml
+keepalive: 60000
+```
+
+---
+
+### `database`
+
+The desired database to use for this Kong instance as a string, matching one of the databases defined under [`databases_available`](#databases_available).
+
+**Default:**
+
+```yaml
+database: cassandra
+```
+
+---
+
+### `database_cache_expiration`
+
+A value specifying (in seconds) how long Kong will keep database entities in memory. Setting this to a high value will cause Kong to avoid making multiple queries to the database in order to retrieve an API's target URL. However, this also means you may be required to wait a while before the
+cached value is flushed and reflects any potential changes made during that time.
+
+**Default:**
+
+```yaml
+database_cache_expiration: 5 # in seconds
+```
+
+---
+
+### `memory_cache_size`
+
+A value specifying (in MB) the size of the internal preallocated in-memory cache. Kong uses an in-memory cache to store database entities in order to optimize access to the underlying datastore. The cache size needs to be as big as the size of the entities being used by Kong at any given time. The default value is `128`, and the potential maximum value is the total size of the datastore.
+
+**Default:**
+
+```yaml
+memory_cache_size: 128 # in megabytes
+```
+
+---
+
+### `nginx`
+
+The NGINX configuration (or `nginx.conf`) that will be used for this instance.
+
+**Warning:** Modifying the NGINX configuration can lead to unexpected results, edit the configuration only if you are confident about doing so.
+
+**Default:**
+
+```yaml
+nginx: |
+  worker_processes auto;
+  error_log logs/error.log info;
+  daemon on;
+
+  worker_rlimit_nofile {{ "{{auto_worker_rlimit_nofile" }}}};
+
+  env KONG_CONF;
+
+  events {
+    worker_connections {{ "{{auto_worker_connections" }}}};
+    multi_accept on;
+  }
+
+  http {
+    resolver 8.8.8.8;
+    charset UTF-8;
+
+    access_log logs/access.log;
+    access_log on;
+
+    # Timeouts
+    keepalive_timeout 60s;
+    client_header_timeout 60s;
+    client_body_timeout 60s;
+    send_timeout 60s;
+
+    # Proxy Settings
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
+    proxy_ssl_server_name on;
+
+    # IP Address
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_recursive on;
+
+    # Other Settings
+    client_max_body_size 128m;
+    underscores_in_headers on;
+    reset_timedout_connection on;
+    tcp_nopush on;
+
+    ################################################
+    #  The following code is required to run Kong  #
+    # Please be careful if you'd like to change it #
+    ################################################
+
+    # Lua Settings
+    lua_package_path ';;';
+    lua_code_cache on;
+    lua_max_running_timers 4096;
+    lua_max_pending_timers 16384;
+    lua_shared_dict cache 512m;
+    lua_socket_log_errors off;
+
+    init_by_lua '
+      kong = require "kong"
+      local status, err = pcall(kong.init)
+      if not status then
+        ngx.log(ngx.ERR, "Startup error: "..err)
+        os.exit(1)
+      end
+    ';
+
+    server {
+      listen {{ "{{proxy_port" }}}};
+
+      location / {
+        default_type 'text/plain';
+
+        # This property will be used later by proxy_pass
+        set $backend_url nil;
+
+        # Authenticate the user and load the API info
+        access_by_lua 'kong.exec_plugins_access()';
+
+        # Proxy the request
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass $backend_url;
+        proxy_pass_header Server;
+
+        # Add additional response headers
+        header_filter_by_lua 'kong.exec_plugins_header_filter()';
+
+        # Change the response body
+        body_filter_by_lua 'kong.exec_plugins_body_filter()';
+
+        # Log the request
+        log_by_lua 'kong.exec_plugins_log()';
+      }
+
+      location /robots.txt {
+        return 200 'User-agent: *\nDisallow: /';
+      }
+
+      error_page 500 /500.html;
+      location = /500.html {
+        internal;
+        content_by_lua '
+          local utils = require "kong.tools.utils"
+          utils.show_error(ngx.status, "Oops, an unexpected error occurred!")
+        ';
+      }
+    }
+
+    server {
+      listen {{ "{{admin_api_port" }}}};
+
+      location / {
+        default_type application/json;
+        content_by_lua 'require("lapis").serve("kong.api.app")';
+      }
+
+      location /robots.txt {
+        return 200 'User-agent: *\nDisallow: /';
+      }
+
+      # Do not remove, additional configuration placeholder for some plugins
+      # {{ "{{additional_configuration" }}}}
+    }
+  }
+```
+
+[cli-reference]: /docs/{{page.kong_version}}/cli
+[yaml]: http://yaml.org

--- a/app/docs/0.2.1/getting-started/adding-consumers.md
+++ b/app/docs/0.2.1/getting-started/adding-consumers.md
@@ -1,0 +1,89 @@
+---
+title: Adding Consumers
+alias: /docs/latest/getting-started/adding-consumers
+---
+
+# Adding Consumers
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="/download">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="/docs/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+    <li>Also, make sure you've <a href="/docs/{{page.kong_version}}/getting-started/adding-your-api">added your API to Kong</a>.</li>
+  </ol>
+</div>
+
+In the last section, we learned how to add plugins to Kong, in this section we're going to learn how to add consumers to your Kong instances. Consumers are associated to individuals using your API, and can be used for tracking, access management, and more.
+
+**Note:** This section assumes you have [enabled][enabling-plugins] the [keyauth][keyauth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
+
+1. ### Create a Consumer through the RESTful API
+
+    Lets create a user named `Jason` by issuing the following request:
+
+    ```bash
+    $ curl -i -X POST \
+       --url http://localhost:8001/consumers/ \
+       --data "username=Jason"
+    ```
+
+    You should see a response similar to the one below:
+
+    ```http
+    HTTP/1.1 201 Created
+    Date: Thu, 09 Apr 2015 05:00:26 GMT
+    Content-Type: application/json
+    Transfer-Encoding: chunked
+    Connection: keep-alive
+    Server: kong/0.1.1beta-2
+
+    {
+     "username": "Jason",
+     "created_at": 1428555626000,
+     "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
+    }
+    ```
+
+    Congratulations! You've just added your first consumer to Kong.
+
+    **Note:** Kong also accepts a `consumer_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
+
+2. ### Provision key credentials for your Consumer
+
+    Now, we can create a key for our recently created consumer `Jason` by issuing the following request with the Consumer `id` from our previous request:
+
+    ```bash
+    $ curl -i -X POST \
+     --url http://localhost:8001/keyauth_credentials/ \
+     --data 'key=ENTER_KEY_HERE' \
+     --data 'consumer_id=bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9'
+    ```
+
+3. ### Verify that your Consumer credentials are valid
+
+    Using the `id` of the Consumer we just created we can issue the following request to verify that the credentials of our Consumer is valid:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000 \
+      --header "Host: mockbin.com" \
+      --header "apikey: ENTER_KEY_HERE"
+    ```
+
+### Next Steps
+
+Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
+
+[mockbin]: https://mockbin.com
+[CLI]: /docs/{{page.kong_version}}/cli
+[API]: /docs/{{page.kong_version}}/admin-api
+[API-consumers]: /docs/{{page.kong_version}}/admin-api#create-consumer
+[keyauth]: /plugins/key-authentication
+[install]: /download
+[plugins]: /plugins
+[configuration]: /docs/{{page.kong_version}}/configuration
+[migrations]: /docs/{{page.kong_version}}/migrations
+[quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart
+[enabling-plugins]: /docs/{{page.kong_version}}/getting-started/enabling-plugins
+[adding-consumers]: /docs/{{page.kong_version}}/getting-started/adding-consumers

--- a/app/docs/0.2.1/getting-started/adding-your-api.md
+++ b/app/docs/0.2.1/getting-started/adding-your-api.md
@@ -1,0 +1,88 @@
+---
+title: Adding your API
+alias: /docs/latest/getting-started/adding-your-api
+---
+
+# Adding your API
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="/download">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="/docs/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+  </ol>
+</div>
+
+In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful API][API] for managing the details of your Kong instances.
+
+1. ### Add your API using the RESTful API
+
+    Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
+
+    ```bash
+    $ curl -i -X POST \
+     --url http://localhost:8001/apis/ \
+     --data 'name=mockbin' \
+     --data 'target_url=http://mockbin.com/' \
+     --data 'public_dns=mockbin.com'
+    ```
+
+    **Note:** Kong handles API configuration requests on port `:8001`
+
+2. ### Verify that your API has been added
+
+    You should see a similar response from the initial request:
+
+    ```http
+    HTTP/1.1 201 Created
+    Date: Wed, 08 Apr 2015 01:26:09 GMT
+    Content-Type: application/json
+    Transfer-Encoding: chunked
+    Connection: keep-alive
+    Server: kong/0.1.1beta-2
+
+    {
+      "public_dns": "mockbin.com",
+      "target_url": "http://mockbin.com/",
+      "id": "2eec1cb2-7093-411a-c14e-42e67142d2c4",
+      "created_at": 1428456369000,
+      "name": "mockbin"
+    }
+    ```
+
+    Kong is now aware of your API and ready to proxy requests.
+
+3. ### Forward your requests through Kong
+
+    Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
+
+    ```bash
+    $ curl -i -X GET \
+     --url http://localhost:8000/ \
+     --header 'Host: mockbin.com'
+    ```
+
+    A successful response means Kong is now forwarding requests to the `target_url` we passed in the first step and giving us the response back. Kong knows to do this through the header defined in the above cURL request:
+
+    <ul>
+      <li><strong>Host: &lt;public_dns></strong></li>
+    </ul>
+
+    **Note:** Kong handles proxy requests on port `:8000`
+
+<hr>
+
+## Next Steps
+
+Now that you've got your API added to Kong lets learn how to enable plugins.
+
+Go to [Enabling Plugins &rsaquo;][enabling-plugins]
+
+[mockbin]: https://mockbin.com
+[CLI]: /docs/{{page.kong_version}}/cli
+[API]: /docs/{{page.kong_version}}/admin-api
+[install]: /download
+[configuration]: /download
+[migrations]: /docs/{{page.kong_version}}/migrations
+[quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart
+[enabling-plugins]: /docs/{{page.kong_version}}/getting-started/enabling-plugins

--- a/app/docs/0.2.1/getting-started/enabling-plugins.md
+++ b/app/docs/0.2.1/getting-started/enabling-plugins.md
@@ -1,0 +1,93 @@
+---
+title: Enabling Plugins
+alias: /docs/latest/getting-started/enabling-plugins
+---
+
+# Enabling Plugins
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="/download">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="/docs/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+    <li>Also, make sure you've <a href="/docs/{{page.kong_version}}/getting-started/adding-your-api">added your API to Kong</a>.</li>
+  </ol>
+</div>
+
+In this section, you'll learn how to enable plugins. One of the core principals of Kong is its extensibility through [plugins][plugins]. Plugins allow you to easily add new features to your API or make your API easier to manage.
+
+First, we'll have you configure and enable the [keyauth][keyauth] plugin to add authentication to your API.
+
+1. ### Add plugin to your Kong config
+
+    Add `keyauth` under the `plugins_available` property in your Kong instance configuration file should it not already exist:
+
+    ```yaml
+    plugins_available:
+     - keyauth
+    ```
+
+2. ### Restart Kong
+
+    Issue the following command to restart Kong. This allows Kong to load the plugin.
+
+    ```bash
+    $ kong restart
+    ```
+
+    **Note:** If you have a cluster of Kong instances that share the configuration, you should restart each node in the cluster.
+
+3. ### Configure the plugin for your API
+
+    Now that Kong has loaded the plugin, we should configure it to be enabled on your API.
+
+    Issue the following cURL request with your API `id` you created previously:
+
+    ```bash
+    $ curl -i -X POST \
+       --url http://localhost:8001/plugins_configurations/ \
+       --data 'name=keyauth' \
+       --data 'api_id=YOUR_API_ID' \
+       --data 'value.key_names=apikey'
+    ```
+
+    **Note:** `value.key_names` is the authentication header name each request will require.
+
+4. ### Verify that the plugin is enabled for your API
+
+    Issue the following cURL request to verify that the [keyauth][keyauth] plugin was enabled for your API:
+
+    ```bash
+    $ curl -i -X GET \
+     --url http://localhost:8000/ \
+     --header 'Host: mockbin.com'
+    ```
+
+    Since you did not specify the required `apikey` header the response should be `403 Forbidden`:
+
+    ```http
+    HTTP/1.1 403 Forbidden
+    ...
+
+    {
+     "message": "Your authentication credentials are invalid"
+    }
+    ```
+
+### Next Steps
+
+Now that you've enabled the **keyauth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
+
+Go to [Adding Consumers &rsaquo;][adding-consumers]
+
+[mockbin]: https://mockbin.com
+[CLI]: /docs/{{page.kong_version}}/cli
+[API]: /docs/{{page.kong_version}}/admin-api
+[keyauth]: /plugins/key-authentication
+[install]: /download
+[plugins]: /plugins
+[configuration]: /download
+[migrations]: /docs/{{page.kong_version}}/migrations
+[quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart
+[enabling-plugins]: /docs/{{page.kong_version}}/getting-started/enabling-plugins
+[adding-consumers]: /docs/{{page.kong_version}}/getting-started/adding-consumers

--- a/app/docs/0.2.1/getting-started/introduction.md
+++ b/app/docs/0.2.1/getting-started/introduction.md
@@ -1,0 +1,27 @@
+---
+title: Welcome to Kong
+alias: /docs/latest/getting-started/introduction
+---
+
+# Welcome to Kong
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong> Make sure you've <a href="/download">installed Kong</a> &mdash; It should only take a minute!
+</div>
+
+
+Now that you know what Kong is and how it works, this guide is going to take you through a quick introduction to Kong. We'll teach you how to use Kong to:
+
+- Running your own Kong instance.
+- Adding and consuming APIs
+- Installing plugins on Kong.
+- *And much more!*
+
+### Next Steps
+
+Now, lets get familiar with learning how to "start" and "stop" Kong.
+
+Go to [5-minute quickstart with Kong &rsaquo;][quickstart]
+
+[install]: /download
+[quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart

--- a/app/docs/0.2.1/getting-started/quickstart.md
+++ b/app/docs/0.2.1/getting-started/quickstart.md
@@ -1,0 +1,65 @@
+---
+title: 5-minute Quickstart
+alias: /docs/latest/getting-started/quickstart
+---
+
+# 5-minute Quickstart
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong> Make sure you've <a href="/download">installed Kong</a> &mdash; It should only take a minute!
+</div>
+
+In this section, you'll learn how to manage your Kong instance. First we'll have you start Kong giving you access to the RESTful interface to manage your APIs, consumers, and more. Data sent through the RESTful interface is stored in your Cassandra instance or cluster, meaning you **must** have Cassandra running **before** starting Kong.
+
+**Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
+
+1. ### Start Kong.
+
+    Issue the following command to start [kong][CLI]:
+
+    ```bash
+    $ kong start
+    ```
+
+    **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
+
+2. ### Verify that Kong has started successfully
+
+    The previous step runs migrations to prepare the Cassandra keyspace.
+    Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
+
+    By default Kong listens on the following ports:
+
+    `:8000` - Proxy layer for API requests
+
+    `:8001` - [RESTful API][API] for configuration
+
+3. ### Stop Kong.
+
+    As needed you can stop the [kong][CLI] process by issuing the following command:
+
+    ```bash
+    $ kong stop
+    ```
+
+4. ### Reload Kong.
+
+    Issue the following command to reload [kong][CLI] without downtime:
+
+    ```bash
+    $ kong reload
+    ```
+
+### Next Steps
+
+Now that you have Kong running you can interact with the RESTful API.
+
+To begin, go to [Adding your API &rsaquo;][adding-your-api]
+
+[CLI]: /docs/{{page.kong_version}}/cli
+[API]: /docs/{{page.kong_version}}/admin-api
+[install]: /download
+[migrations]: /docs/{{page.kong_version}}/migrations
+[quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart
+[configuration]: /docs/{{page.kong_version}}/configuration
+[adding-your-api]: /docs/{{page.kong_version}}/getting-started/adding-your-api

--- a/app/docs/0.2.1/index.md
+++ b/app/docs/0.2.1/index.md
@@ -1,0 +1,39 @@
+---
+title: Documentation for Kong
+permalink: /docs/
+alias: /docs/latest
+---
+
+# Kong Documentation
+
+<div class="docs-grid">
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="/download">Installation</a></h3>
+    <p>You can install Kong on most Linux distributions and OS X. We even provide the source so you can compile yourself.</p>
+    <a href="/download">Install Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-quickstart.svg" /><a href="/docs/{{page.kong_version}}/getting-started/quickstart">5-minute Quickstart</a></h3>
+    <p>Learn how to start Kong, add your API, enable plugins, and add consumers in under thirty seconds.</p>
+    <a href="/docs/{{page.kong_version}}/getting-started/quickstart">Start using Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+     <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/configuration">Configuration</a></h3>
+     <p>Want to further optimize your Kong cluster, database, or configure NGINX? Dive into the configuration.</p>
+     <a href="/docs/{{page.kong_version}}/configuration">Start configuring Kong &rarr;</a>
+   </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/admin-api">API reference</a></h3>
+    <p>Ready to learn the underlying interface? Browse the API reference to learn how to start making requests.</p>
+    <a href="/docs/{{page.kong_version}}/admin-api">Explore the interface &rarr;</a>
+  </div>
+
+   <div class="docs-grid-block">
+      <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/cli">CLI reference</a></h3>
+      <p>Want a better understanding of the CLI tool and its options? Browse the detailed command reference.</p>
+      <a href="/docs/{{page.kong_version}}/cli">Use the CLI &rarr;</a>
+    </div>
+</div>

--- a/app/docs/0.2.1/tutorials/hello-world.md
+++ b/app/docs/0.2.1/tutorials/hello-world.md
@@ -1,0 +1,32 @@
+---
+title: Tutorials - Hello World
+alias: /docs/latest/tutorials/hello-world
+---
+
+# Hello World: Proxying your first API
+
+Kong sits in front of any configured API, and it's the main entry point of any HTTP request. For example, let's configure Kong to support [mockbin](http://mockbin.com/) as an API:
+
+```
+$ curl -i -X POST \
+  --url http://127.0.0.1:8001/apis/ \
+  --data 'name=mockbin&target_url=http://mockbin.com&public_dns=api.mockbin.com'
+HTTP/1.1 201 Created
+```
+
+We used the `8001` port, which the RESTful Admin API of Kong listens on.
+
+We can now make our first HTTP requests through Kong by using the `8000` port, which is the port that API consumers will use to consume any API behind Kong:
+
+```
+$ curl -i -X GET \
+  --url http://127.0.0.1:8000/ \
+  --header 'Host: api.mockbin.com'
+HTTP/1.1 200 OK
+```
+
+Kong accepted the request and proxied it to the `target_url` property we configured when adding the API, `http://mockbin.com`, and sent us the response.
+
+On a side note you will notice a little trick: we are requesting the API on `127.0.0.1` by manually setting the `Host` header to match the `public_dns` of the API. This will fool the system by making it believe the request has been made to `api.mockbin.com`. In production you want to setup a DNS record that will reference the domain name to your Kong servers through a CNAME or A record, thus avoiding doing this trick. If Kong is sitting behind a load balancer, then the domain should target the load balancer.
+
+Congratulations! The API has been successfully added to Kong and now we can start adding functionalities on top of it.

--- a/app/docs/0.2.1/tutorials/installing-plugin.md
+++ b/app/docs/0.2.1/tutorials/installing-plugin.md
@@ -1,0 +1,101 @@
+---
+title: Tutorials - Installing a Plugin
+alias: /docs/latest/tutorials/installing-plugin
+---
+
+# Installing a Plugin
+
+One of Kong's core principle is its extensibility through [Plugins](/plugins/), which allow you to add features to your APIs.
+
+Let's configure the [Key Authentication](/plugins/key-authentication/) plugin to add a simple key authentication to the API.
+
+## 1. Enabling the Plugin
+
+We need to make sure that the plugin name is in the `plugins_available` property of your node's configuration:
+
+```yaml
+plugins_available:
+  - keyauth
+```
+
+This will make Kong load the plugin. When changing the configuration file, we need to restart Kong:
+
+```bash
+$ kong restart
+```
+
+Repeat this step for every node in your cluster.
+
+## 2. Configuring the Plugin
+
+To enable the plugin on the API, we need to retrieve the API `id` that has been created when we added the API on Kong. We can list all of the APIs configured on Kong by executing:
+
+```
+$ curl http://127.0.0.1:8001/apis/
+```
+
+Once we have got the `id` of the API, we can configure the key authentication plugin by performing a `POST` request with the following parameters:
+
+* **name**: name of the Plugin
+* **api_id**: `id` of the API the plugin will be added to
+* **value.key_names**: `value` is a property that is being shared by every plugin, and it is where their configuration is being set. As documented in the [Plugin's Profile](/plugins/key-authentication/#configuration), `key_names` is a comma-separated string array that represents the key names, header names or JSON property names where Kong will look for a credential.
+
+We would like every API consumer to send their credential in an `apikey` field, so we would configure the Plugin like this:
+
+```bash
+$ curl -i -X POST \
+  --url http://127.0.0.1:8001/plugins_configurations/ \
+  --data 'name=keyauth&api_id=<api_id>&value.key_names=apikey'
+HTTP/1.1 201 Created
+...
+{
+  "api_id": "<api_id>",
+  "value": { "key_names":["apikey"], "hide_credentials":false },
+  "id": "<id>",
+  "enabled": true,
+  "name": "keyauth"
+}
+```
+
+Here we go, the Plugin has been successfully configured and enabled.
+
+If we now try to make an HTTP request to the same API, Kong will tell us that we are not authenticated to make the request.
+
+```bash
+$ curl -i -X GET \
+  --url http://127.0.0.1:8000/ \
+  --header 'Host: api.mockbin.com'
+HTTP/1.1 403 Forbidden
+...
+{ "message": "Your authentication credentials are invalid" }
+```
+
+That happened because the request we made didn't provide a key named `apikey` (as specified by our plugin configuration) and it has been blocked by Kong. The request never reached the final API.
+
+To authenticate against the API, we need to pass a credential along with the request. As documented in the [Plugin's Usage](/plugins/key-authentication/), we need to create a [Consumer](/docs/{{site.data.kong_latest.version}}/api/#consumer-object) and a credential key:
+
+```bash
+$ curl -i -X POST \
+  --url http://127.0.0.1:8001/consumers/ \
+  --data 'username=tutorial_user'
+HTTP/1.1 201 Created
+
+# Make sure the given consumer_id matches the freshly created account:
+$ curl -i -X POST \
+  --url http://127.0.0.1:8001/keyauth_credentials/
+  --data 'key=123456&consumer_id=<consumer_id>'
+HTTP/1.1 201 Created
+```
+
+That consumer with an associated `123456` key credential can now consume the API. We can retry to make the request passing the proper value into an `apikey` parameter:
+
+```bash
+$ curl -i -X GET \
+  --url http://127.0.0.1:8000/?apikey=123456 \
+  --header 'Host: api.mockbin.com'
+HTTP/1.1 200 OK
+```
+
+Success! The request was proxied successfully to the final API.
+
+To go further into mastering Kong and its plugins, refer to the complete [documentation](/docs/), and read carefully each plugin's instruction in the [Plugins Gallery](/plugins/).

--- a/app/docs/0.2.1/tutorials/introduction.md
+++ b/app/docs/0.2.1/tutorials/introduction.md
@@ -1,0 +1,31 @@
+---
+title: Tutorials - Introduction
+alias: /docs/latest/tutorials/introduction
+---
+
+# Introduction
+
+The following tutorials assume that Kong has been properly installed using one of the [available installation methods](/download).
+
+Kong will look by default for a configuration file at `/etc/kong/kong.yml`. If you installed Kong from luarocks, you can copy the default configuration from the luarocks tree (luarocks --help to print it). Usually:
+
+```
+cp /usr/local/lib/luarocks/rocks/kong/<kong_version>/conf/kong.yml /etc/kong/kong.yml
+```
+
+Edit the configuration to let Kong access your Cassandra cluster.
+
+Let's start Kong:
+
+```
+kong start
+```
+
+If this is the first time running Kong, the `start` command will also automatically run database migrations to prepare the Cassandra keyspace.
+
+Once Kong is started it will listen by default on the following ports:
+
+* `8000`, that will accept incoming HTTP request to be proxied to the final APIs
+* `8001`, that exposes Kong's administration API to operate the system
+
+Port `8001` should be firewalled to prevent unauthorized access.


### PR DESCRIPTION
This PR is where the 0.2.1 docs should be updated.

For now, the docs **are still under 0.2.0** so we are able to see what changed in between those 2 versions in term fo documentation. Before merging, one will have to rename the folder to 0.2.1 and retrieve the old 0.2.0 folder. Fixing the redirections from `latest`, etc.

Still missing before releasing:
- A dropdown to switch the version
- An alert saying the docs are outdated #61