### PR TITLE
Changed the needed `name` parameter in filelog pg

### DIFF
--- a/app/plugins/file-log.md
+++ b/app/plugins/file-log.md
@@ -38,7 +38,7 @@ $ curl -X POST http://kong:8001/plugins_configurations/ \
 
 parameter                     | description
  ---                          | ---
-`name`                        | The name of the plugin to use, in this case: `tcplog`
+`name`                        | The name of the plugin to use, in this case: `filelog`
 `api_id`                      | The API ID that this plugin configuration will target
 `consumer_id`<br>*optional*   | The CONSUMER ID that this plugin configuration will target
 


### PR DESCRIPTION
Looks like it was copied from the tcplog page.