### PR TITLE
docs: New proxy layer reference draft

### DIFF
--- a/app/docs/0.3.2/getting-started/adding-your-api.md
+++ b/app/docs/0.3.2/getting-started/adding-your-api.md
@@ -73,6 +73,11 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles proxy requests on port `:8000`
 
+    <div class="alert alert-warning">
+      <strong>Going further:</strong>
+      For a full understanding of how to proxy requests through Kong, check out the <a href="/docs/{{page.kong_version}}/proxy-layer-reference">Proxy Layer reference</a>.
+    </div>
+
 <hr>
 
 ## Next Steps

--- a/app/docs/0.3.2/proxy-layer-reference.md
+++ b/app/docs/0.3.2/proxy-layer-reference.md
@@ -46,7 +46,7 @@ This guide will cover all proxying capabilities of Kong by explaining in detail 
 
 When receiving a request, Kong will inspect it and try to route it to the correct API. In order to do so, it supports different routing mechanisms depending on your needs. A request can be routed by:
 
-- A **DNS** value contained in a header of the request.
+- A **DNS** value contained in the **Host** header of the request.
 - The path (**URI**) of the request.
 
 <div class="alert alert-warning">
@@ -91,12 +91,12 @@ $ curl -i -X GET \
 By doing so, Kong recognizes the `Host` value as being the `public_dns` of the "mockbin" API. The request will be routed to the upstream API and Kong will execute any configured [plugin][plugins] for that API.
 
 <div class="alert alert-warning">
-  <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "**Host**" header on each request. You can let Kong and DNS take care of it by simply setting an A record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
+  <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
 #### Using the "**X-Host-Override**" header
 
-When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for header named `X-Host-Override` and treats it exactly like the `Host` header:
+When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
 ```bash
 $ curl -i -X GET \
@@ -108,7 +108,7 @@ This request will be proxied just as well by Kong.
 
 #### Using a wildcard DNS
 
-Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**public_dns**"" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
+Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**public_dns**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
 A "**public_dns**" of form `*.example.org` will route requests with "**Host**" values such as `a.example.org` or `x.y.example.org`.
 
@@ -118,7 +118,7 @@ A "**public_dns**" of form `example.*` will route requests with "**Host**" value
 
 ## 4. Proxy an API by its path value
 
-If you'd rather configure your APIs so that Kong routes incoming requests according to the request's URI, Kong can also perform this funtion. This allows your consumers to seamlessly consume APIs without making them specify a Host header.
+If you'd rather configure your APIs so that Kong routes incoming requests according to the request's URI, Kong can also perform this function. This allows your consumers to seamlessly consume APIs sparing the headache of setting DNS records for your domains.
 
 Because the API we previously configured has a `path` property, the following request will **also** be proxied to the upstream "mockbin" API:
 
@@ -161,12 +161,12 @@ Once Kong has recognized which API an incoming request should be proxied to, it 
 
 - 1. Kong recognized the API (according to one of the previously explained methods)
 - 2. It looks into the datastore for Plugin Configurations for that API
-- 3. Some Plugin Configurations were found
+- 3. Some Plugin Configurations were found, for example:
   - a. A key authentication Plugin Configuration
   - b. A ratelimiting Plugin Configuration (that also has a `consumer_id` property)
 - 4. Kong executes the highest priority plugin (key authentication in this case)
   - a. User is now authenticated
-- 5. Kong tries executes the ratelimiting plugin
+- 5. Kong tries to execute the ratelimiting plugin
   - a. If the user is the one in the `consumer_id`, ratelimiting is applied
   - b. If the user is not the one configured, ratelimiting is not applied
 - 6. Request is proxied

--- a/app/docs/0.3.2/proxy-layer-reference.md
+++ b/app/docs/0.3.2/proxy-layer-reference.md
@@ -1,0 +1,179 @@
+---
+title: Proxy Layer Reference
+---
+
+# Proxy Layer Reference
+
+As you might already know, Kong uses two ports to communicate. By default, they are:
+
+`:8001` - The one on which the [Admin API][API] listens.
+
+`:8000` - Where Kong listens for incoming requests to proxy to your upstream services. This is the port that interests us here. Here is a typical request workflow on this port:
+
+<br />
+
+![](/assets/images/docs/kong-simple.png)
+
+<br />
+
+This guide will cover all proxying capabilities of Kong by explaining in details how the proxying (`8000`) port works under the hood.
+
+## Summary
+
+- 1. [How does Kong route a request to an API][1]
+- 2. [Reminder: how to add an API to Kong][2]
+- 3. [Proxy an API by its DNS value][3]
+  - [Using the "Host" header][3a]
+  - [Using the "X-Host-Override" header][3b]
+  - [Using a wildcard DNS][3c]
+- 4. [Proxy an API by its path value][4]
+  - [Using the "strip_path" property][4a]
+- 5. [Plugins execution][5]
+
+[1]: #1.-how-does-kong-route-a-request-to-an-api
+[2]: #2.-reminder:-how-to-add-an-api-to-kong
+[3]: #3.-proxy-an-api-by-its-dns-value
+[3a]: #using-the-"host"-header
+[3b]: #using-the-"x-host-override"-header
+[3c]: #using-a-wildcard-dns
+[4]: #4.-proxy-an-api-by-its-path-value
+[4a]: #using-the-"strip_path"-property
+[5]: #5.-plugins-execution
+
+---
+
+## 1. How does Kong route a request to an API
+
+When receiving a request, Kong will inspect it and try to route it to the correct API. In order to do so, it supports different routing mechanisms depending on your needs. A request can be routed by:
+
+- A **DNS** value contained in a header of the request.
+- The path (**URI**) of the request.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> For performance reasons, Kong keeps a cache of the APIs from your Cassandra cluster in memory for up to 60 seconds. Cache invalidation not being implemented yet, Kong might take up to <strong>60 seconds</strong> to notice a new API and proxy incoming requests to it.
+</div>
+
+---
+
+## 2. Reminder: how to add an API to Kong
+
+Before going any further, let's take a few moments to make sure you know how to add an API to Kong. This also help clarifying the difference between the two ports.
+
+As explained in the [Adding your API][adding-your-api] quickstart guide, Kong is configured via its internal [Admin API][API] running by default on port `8001`. Adding an API to Kong is as easy as an HTTP request:
+
+```bash
+$ curl -i -X POST \
+ --url http://localhost:8001/apis/ \
+ -d 'name=mockbin' \
+ -d 'target_url=http://mockbin.com/' \
+ -d 'public_dns=mockbin.com' \
+ -d 'path=/status'
+```
+
+This request tells Kong to add an API named "**mockbin**", with its upstream ressource being located at "**http://mockbin.com**". The `public_dns` and `path` properties are the ones used by Kong to route a request to that API. They are not both required but at least one of them must be specified.
+
+Once this request is processed by Kong, the API is stored in your Cassandra cluster and a request to the **Proxy port** will trigger a query to Cassandra and put your API in Kong's proxying cache.
+
+---
+
+## 3. Proxy an API by its DNS value
+
+#### Using the "**Host**" header
+
+Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `public_dns` value in the `Host` header of your request:
+
+```bash
+$ curl -i -X GET \
+ --url http://localhost:8000/ \
+ --header 'Host: mockbin.com'
+```
+
+By doing so, Kong recognizes the `Host` value as being the `public_dns` of the "mockbin" API. The request will be routed to the upstream API and Kong will execute any configured [plugin][plugins] for that API.
+
+<div class="alert alert-warning">
+  <strong>Going to production:</strong> If you're planning on going to production with your setup, you most likely don't want your consumers to manually set the "**Host**" header on each request. You can let Kong and DNS take care of it by simply setting an A record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
+</div>
+
+#### Using the "**X-Host-Override**" header
+
+When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for header named `X-Host-Override` and treats it exactly like the `Host` header:
+
+```bash
+$ curl -i -X GET \
+ --url http://localhost:8000/ \
+ --header 'X-Host-Override: mockbin.com'
+```
+
+This request will be proxied just as well by Kong.
+
+#### Using a wildcard DNS
+
+Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**public_dns**"" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
+
+A "**public_dns**" of form `*.example.org` will route requests with "**Host**" values such as `a.example.org` or `x.y.example.org`.
+
+A "**public_dns**" of form `example.*` will route requests with "**Host**" values such as `example.com` or `example.org`.
+
+---
+
+## 4. Proxy an API by its path value
+
+If you'd rather configure your APIs so that Kong routes incoming request according to the request's URI, Kong can also do that. This allows for example your consumers to seamlessly consume APIs without making them specify a Host header.
+
+Because the API we previously configured has a `path` property, the following request will **also** be proxied to the upstream "mockbin" API:
+
+```bash
+$ curl -i -X GET \
+ --url http://localhost:8000/status/200
+```
+
+You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `target_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
+
+#### Using the "**strip_path**" property
+
+By enabling the `strip_path` property on an API, the requests will be proxied without the `path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
+
+```bash
+$ curl -i -X PATCH \
+ --url http://localhost:8001/apis/mockbin \
+ -d 'strip_path=true' \
+ -d 'path=/mockbin'
+```
+
+Now that we slightly updated our API (you might have to wait a few seconds for Kong's proxying cache to be updated), Kong will proxy requests made to `KONG_URL:PROXY_PORT/mockbin` but will not include the `/mockbin` part when performing the upstream request.
+
+Here is a table documenting the behaviour of the path routing depending on your API's configuration:
+
+`path`      | `strip_path`   | incoming request       | upstream request
+ ---        | ---            | ---                    | ---
+`/mockbin`  | **false**      | `/some_path`           | **not proxied**
+`/mockbin`  | **false**      | `/mockbin`             | `/mockbin`
+`/mockbin`  | **false**      | `/mockbin/some_path`   | `/mockbin/some_path`
+`/mockbin`  | **true**       | `/some_path`           | **not proxied**
+`/mockbin`  | **true**       | `/mockbin`             | `/`
+`/mockbin`  | **true**       | `/mockbin/some_path`   | `/some_path`
+
+---
+
+## 5. Plugins execution
+
+Once Kong has recognized which API an incoming request should be proxied to, it will look into your Cassandra cluster for any record of a [Plugin Configuration][plugin-configuration-object] for that particular API. This is done according to the following steps:
+
+- 1. Kong recognized the API (according to one of the previously explained methods)
+- 2. It looks into the datastore for Plugin Configurations for that API
+- 3. Some Plugin Configurations were found
+  - a. A key authentication Plugin Configuration
+  - b. A ratelimiting Plugin Configuration (that also has a `consumer_id` property)
+- 4. Kong executes the highest priority plugin (key authentication in this case)
+  - a. User is now authenticated
+- 5. Kong tries executes the ratelimiting plugin
+  - a. If the user is the one in the `consumer_id`, ratelimiting is applied
+  - b. If the user is not the one configured, ratelimiting is not applied
+- 6. Request is proxied
+
+**Note**: The proxying of the request might happen before or after plugins execution, since each plugin can hook itself anywhere in the lifecycle of a request. In this case (authentication + ratelimiting), it is of course mandatory that those plugins be executed **before** proxying happens.
+
+[adding-your-api]: /docs/{{page.kong_version}}/getting-started/adding-your-api
+[API]: /docs/{{page.kong_version}}/admin-api
+[plugin-configuration-object]: /docs/{{page.kong_version}}/admin-api#plugin-configuration-object
+[plugins]: /plugins/

--- a/app/docs/0.3.2/proxy-layer-reference.md
+++ b/app/docs/0.3.2/proxy-layer-reference.md
@@ -4,11 +4,11 @@ title: Proxy Layer Reference
 
 # Proxy Layer Reference
 
-As you might already know, Kong uses two ports to communicate. By default, they are:
+As you might already know, Kong uses two ports to communicate. By default they are:
 
 `:8001` - The one on which the [Admin API][API] listens.
 
-`:8000` - Where Kong listens for incoming requests to proxy to your upstream services. This is the port that interests us here. Here is a typical request workflow on this port:
+`:8000` - Where Kong listens for incoming requests to proxy to your upstream services. This is the port that interests us; here is a typical request workflow on this port:
 
 <br />
 
@@ -16,7 +16,7 @@ As you might already know, Kong uses two ports to communicate. By default, they 
 
 <br />
 
-This guide will cover all proxying capabilities of Kong by explaining in details how the proxying (`8000`) port works under the hood.
+This guide will cover all proxying capabilities of Kong by explaining in detail how the proxying (`8000`) port works under the hood.
 
 ## Summary
 
@@ -50,14 +50,14 @@ When receiving a request, Kong will inspect it and try to route it to the correc
 - The path (**URI**) of the request.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> For performance reasons, Kong keeps a cache of the APIs from your Cassandra cluster in memory for up to 60 seconds. Cache invalidation not being implemented yet, Kong might take up to <strong>60 seconds</strong> to notice a new API and proxy incoming requests to it.
+  <strong>Note:</strong> For performance reasons, Kong keeps a cache of the APIs from your Cassandra cluster in memory for up to 60 seconds. As cache invalidation has not been implemented yet, Kong might take up to <strong>60 seconds</strong> to notice a new API and proxy incoming requests to it.
 </div>
 
 ---
 
 ## 2. Reminder: how to add an API to Kong
 
-Before going any further, let's take a few moments to make sure you know how to add an API to Kong. This also help clarifying the difference between the two ports.
+Before going any further, let's take a few moments to make sure you know how to add an API to Kong. This will also help clarify the difference between the two ports.
 
 As explained in the [Adding your API][adding-your-api] quickstart guide, Kong is configured via its internal [Admin API][API] running by default on port `8001`. Adding an API to Kong is as easy as an HTTP request:
 
@@ -70,7 +70,7 @@ $ curl -i -X POST \
  -d 'path=/status'
 ```
 
-This request tells Kong to add an API named "**mockbin**", with its upstream ressource being located at "**http://mockbin.com**". The `public_dns` and `path` properties are the ones used by Kong to route a request to that API. They are not both required but at least one of them must be specified.
+This request tells Kong to add an API named "**mockbin**", with its upstream resource being located at "**http://mockbin.com**". The `public_dns` and `path` properties are the ones used by Kong to route a request to that API. Both properties are not required but at least one must be specified.
 
 Once this request is processed by Kong, the API is stored in your Cassandra cluster and a request to the **Proxy port** will trigger a query to Cassandra and put your API in Kong's proxying cache.
 
@@ -91,7 +91,7 @@ $ curl -i -X GET \
 By doing so, Kong recognizes the `Host` value as being the `public_dns` of the "mockbin" API. The request will be routed to the upstream API and Kong will execute any configured [plugin][plugins] for that API.
 
 <div class="alert alert-warning">
-  <strong>Going to production:</strong> If you're planning on going to production with your setup, you most likely don't want your consumers to manually set the "**Host**" header on each request. You can let Kong and DNS take care of it by simply setting an A record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
+  <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "**Host**" header on each request. You can let Kong and DNS take care of it by simply setting an A record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
 #### Using the "**X-Host-Override**" header
@@ -118,7 +118,7 @@ A "**public_dns**" of form `example.*` will route requests with "**Host**" value
 
 ## 4. Proxy an API by its path value
 
-If you'd rather configure your APIs so that Kong routes incoming request according to the request's URI, Kong can also do that. This allows for example your consumers to seamlessly consume APIs without making them specify a Host header.
+If you'd rather configure your APIs so that Kong routes incoming requests according to the request's URI, Kong can also perform this funtion. This allows your consumers to seamlessly consume APIs without making them specify a Host header.
 
 Because the API we previously configured has a `path` property, the following request will **also** be proxied to the upstream "mockbin" API:
 
@@ -171,7 +171,7 @@ Once Kong has recognized which API an incoming request should be proxied to, it 
   - b. If the user is not the one configured, ratelimiting is not applied
 - 6. Request is proxied
 
-**Note**: The proxying of the request might happen before or after plugins execution, since each plugin can hook itself anywhere in the lifecycle of a request. In this case (authentication + ratelimiting), it is of course mandatory that those plugins be executed **before** proxying happens.
+**Note**: The proxying of a request might happen before or after plugins execution, since each plugin can hook itself anywhere in the lifecycle of a request. In this case (authentication + ratelimiting) it is of course mandatory those plugins be executed **before** proxying happens.
 
 [adding-your-api]: /docs/{{page.kong_version}}/getting-started/adding-your-api
 [API]: /docs/{{page.kong_version}}/admin-api


### PR DESCRIPTION
This guide describes the behaviour of the `8000` port and explains all the ways Kong can route requests to the configured upstream services.

It addresses #80, #104, and eventually #87 through a brief note. A "Going to production" guide would be a good addition for the docs, and a good conclusion chapter to that guide.

Please review for feedback about content and language!