### PR TITLE
fix plugin development admin-api compile error

### DIFF
--- a/app/docs/0.6.x/plugin-development/admin-api.md
+++ b/app/docs/0.6.x/plugin-development/admin-api.md
@@ -75,7 +75,7 @@ Example:
 ```lua
 local crud = require "kong.api.crud_helpers"
 
-return = {
+return {
   ["/consumers/:username_or_id/key-auth/"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)


### PR DESCRIPTION
The change fixes compile error for plugin development admin api example.