### PR TITLE
Adds list of community tools to community page

### DIFF
--- a/app/community/index.html
+++ b/app/community/index.html
@@ -4,6 +4,89 @@ layout: default
 header_title: Community
 header_icon: /assets/images/icons/icn-community.svg
 header_caption: Be part part of the movement and join the growing Kong community
+community_tools:
+  - name: Ansible role for Kong on Ubuntu
+    website: https://github.com/Getsidecar/ansible-role-kong
+  
+  - name: Biplane
+    description: "declarative configuration in Crystal"
+    website: https://github.com/articulate/biplane
+    
+  - name: Bonobo
+    description: "key management (with Mashery migration scripts)"
+    website: https://github.com/guardian/bonobo
+    
+  - name: Chef Cookbook
+    website: https://github.com/zuazo/kong-cookbook
+    
+  - name: Django Kong Admin
+    description: "Admin UI in JavaScript"
+    website: https://github.com/vikingco/django-kong-admin
+    
+  - name: Jungle
+    description: "Admin UI in JavaScript"
+    website: https://github.com/rsdevigo/jungle
+    
+  - name: Kong Dashboard
+    description: "Admin UI in JavaScript"
+    website: https://github.com/PGBI/kong-dashboard
+    
+  - name: Kong for CanopyCloud
+    website: https://github.com/CanopyCloud/cip-kong
+    
+  - name: Kong image waiting for Cassandra
+    website: https://github.com/articulate/docker-kong-wait
+    
+  - name: Kong image for Tatum
+    website: https://github.com/Sillelien/docker-kong
+    
+  - name: Kong-UI
+    description: "Admin UI in JavaScript"
+    website: https://github.com/msaraf/kong-ui
+    
+  - name: Konga
+    description: "CLI Admin tool in JavaScript"
+    website: https://github.com/Floby/konga-cli
+    
+  - name: Kongfig
+    description: "Declarative configuration in JavaScript"
+    website: https://github.com/mybuilder/kongfig
+    
+  - name: Kongfig on Puppet Forge
+    website: https://forge.puppet.com/mybuilder/kongfig
+    
+  - name: Puppet receipe
+    website: https://github.com/scottefein/puppet-nyt-kong
+    
+  - name: Python-Kong
+    description: "Admin client library for Python"
+    website: https://pypi.python.org/pypi/python-kong/
+    
+  - name: .NET-Kong
+    description: "Admin client library for .NET"
+    website: https://www.nuget.org/packages/Kong/0.0.4
+    
+community_meetups:
+  - name: Kong San Francisco
+    website: http://www.meetup.com/Kong-SF/
+  
+  - name: Kong Boston
+    website: http://www.meetup.com/Kong-BOSTON/
+    
+  - name: Kong London
+    website: http://www.meetup.com/Kong-LONDON/
+    
+  - name: Kong Detroit
+    website: http://www.meetup.com/Kong-DETROIT/
+    
+  - name: Kong New York
+    website: http://www.meetup.com/Kong-NY/
+    
+  - name: Kong Amsterdam
+    website: http://www.meetup.com/Kong-AMSTERDAM/
+    
+  - name: Kong Tokyo
+    website: http://www.meetup.com/Kong-TOKYO
 ---
 
 <div class="page page-community">
@@ -78,39 +161,25 @@ header_caption: Be part part of the movement and join the growing Kong community
         </li>
       </ul>-->
 
+      <!-- Meetups -->
       <h3><img src="/assets/images/logos/logo-meetup.png" width="48" height="32" alt="Meetup"/>Kong Community Meetups</h3>
 
       <ul>
         <li>Be part of the Kong Community and <a href="http://kong.meetup.com/" target="_blank">start</a> yours or join one of these meetups below!</li>
-        <li><a href="http://www.meetup.com/Kong-SF/" target="_blank">Kong San Francisco</a></li>
-        <li><a href="http://www.meetup.com/Kong-BOSTON/" target="_blank">Kong Boston</a></li>
-        <li><a href="http://www.meetup.com/Kong-LONDON/" target="_blank">Kong London</a></li>
-        <li><a href="http://www.meetup.com/Kong-DETROIT/" target="_blank">Kong Detroit</a></li>
-        <li><a href="http://www.meetup.com/Kong-NY/" target="_blank">Kong New York</a></li>
-        <li><a href="http://www.meetup.com/Kong-AMSTERDAM/" target="_blank">Kong Amsterdam</a></li>
-        <li><a href="http://www.meetup.com/Kong-TOKYO" target="_blank">Kong Tokyo</a></li>
+      
+      {% for community in page.community_meetups %}
+        <li><a href="{{ community.website }}" target="_blank">{{ community.name }}</a>
+      {% endfor %}
       </ul>
       
+      
+      <!-- Community Tools -->
       <h3><img src="/assets/images/icons/icn-developers-blue.svg" width="48" height="32" alt="Meetup"/>Tools Maintained By The Community</h3>
-
+      
       <ul>
-        <li><a href="https://github.com/Getsidecar/ansible-role-kong" target="_blank">Ansible role for Kong on Ubuntu</a></li>
-        <li><a href="https://github.com/articulate/biplane" target="_blank">Biplane</a>: declarative configuration in Crystal</li>
-        <li><a href="https://github.com/guardian/bonobo" target="_blank">Bonobo</a>: key management (with Mashery migration scripts)</li>
-        <li><a href="https://github.com/zuazo/kong-cookbook" target="_blank">Chef Cookbook</a></li>
-        <li><a href="https://github.com/vikingco/django-kong-admin" target="_blank">Django Kong Admin</a>: Admin UI in JavaScript</li>
-        <li><a href="https://github.com/rsdevigo/jungle" target="_blank">Jungle</a>: Admin UI in JavaScript</li>
-        <li><a href="https://github.com/PGBI/kong-dashboard" target="_blank">Kong Dashboard</a>: Admin UI in JavaScript</li>
-        <li><a href="https://github.com/CanopyCloud/cip-kong" target="_blank">Kong for CanopyCloud</a></li>
-        <li><a href="https://github.com/articulate/docker-kong-wait" target="_blank">Kong image waiting for Cassandra</a></li>
-        <li><a href="https://github.com/Sillelien/docker-kong" target="_blank">Kong image for Tatum</a></li>
-        <li><a href="https://github.com/msaraf/kong-ui" target="_blank">Kong-UI</a>: Admin UI in JavaScript</li>
-        <li><a href="https://github.com/Floby/konga-cli" target="_blank">Konga</a>: CLI Admin tool in JavaScript</li>
-        <li><a href="https://github.com/mybuilder/kongfig" target="_blank">Kongfig</a>: Declarative configuration in JavaScript</li>
-        <li><a href="https://forge.puppet.com/mybuilder/kongfig" target="_blank">Kongfig on Puppet Forge</a></li>
-        <li><a href="https://github.com/scottefein/puppet-nyt-kong" target="_blank">Puppet receipe</a></li>
-        <li><a href="https://pypi.python.org/pypi/python-kong/" target="_blank">Python-Kong</a>Admin client library for Python</li>
-        <li><a href="https://www.nuget.org/packages/Kong/0.0.4" target="_blank">.NET-Kong</a>: Admin client library for .NET</li>
+      {% for tool in page.community_tools %}
+        <li><a href="{{ tool.website }}" target="_blank">{{ tool.name }}</a>{% if tool.description %}: {{tool.description}}{% endif %}</li>
+      {% endfor %}
       </ul>
       
     </div>

--- a/app/community/index.html
+++ b/app/community/index.html
@@ -89,9 +89,30 @@ header_caption: Be part part of the movement and join the growing Kong community
         <li><a href="http://www.meetup.com/Kong-NY/" target="_blank">Kong New York</a></li>
         <li><a href="http://www.meetup.com/Kong-AMSTERDAM/" target="_blank">Kong Amsterdam</a></li>
         <li><a href="http://www.meetup.com/Kong-TOKYO" target="_blank">Kong Tokyo</a></li>
-
-
       </ul>
+      
+      <h3><img src="/assets/images/icons/icn-developers-blue.svg" width="48" height="32" alt="Meetup"/>Tools Maintained By The Community</h3>
+
+      <ul>
+        <li><a href="https://github.com/Getsidecar/ansible-role-kong" target="_blank">Ansible role for Kong on Ubuntu</a></li>
+        <li><a href="https://github.com/articulate/biplane" target="_blank">Biplane</a>: declarative configuration in Crystal</li>
+        <li><a href="https://github.com/guardian/bonobo" target="_blank">Bonobo</a>: key management (with Mashery migration scripts)</li>
+        <li><a href="https://github.com/zuazo/kong-cookbook" target="_blank">Chef Cookbook</a></li>
+        <li><a href="https://github.com/vikingco/django-kong-admin" target="_blank">Django Kong Admin</a>: Admin UI in JavaScript</li>
+        <li><a href="https://github.com/rsdevigo/jungle" target="_blank">Jungle</a>: Admin UI in JavaScript</li>
+        <li><a href="https://github.com/PGBI/kong-dashboard" target="_blank">Kong Dashboard</a>: Admin UI in JavaScript</li>
+        <li><a href="https://github.com/CanopyCloud/cip-kong" target="_blank">Kong for CanopyCloud</a></li>
+        <li><a href="https://github.com/articulate/docker-kong-wait" target="_blank">Kong image waiting for Cassandra</a></li>
+        <li><a href="https://github.com/Sillelien/docker-kong" target="_blank">Kong image for Tatum</a></li>
+        <li><a href="https://github.com/msaraf/kong-ui" target="_blank">Kong-UI</a>: Admin UI in JavaScript</li>
+        <li><a href="https://github.com/Floby/konga-cli" target="_blank">Konga</a>: CLI Admin tool in JavaScript</li>
+        <li><a href="https://github.com/mybuilder/kongfig" target="_blank">Kongfig</a>: Declarative configuration in JavaScript</li>
+        <li><a href="https://forge.puppet.com/mybuilder/kongfig" target="_blank">Kongfig on Puppet Forge</a></li>
+        <li><a href="https://github.com/scottefein/puppet-nyt-kong" target="_blank">Puppet receipe</a></li>
+        <li><a href="https://pypi.python.org/pypi/python-kong/" target="_blank">Python-Kong</a>Admin client library for Python</li>
+        <li><a href="https://www.nuget.org/packages/Kong/0.0.4" target="_blank">.NET-Kong</a>: Admin client library for .NET</li>
+      </ul>
+      
     </div>
   </div>
 </div>


### PR DESCRIPTION
Updates https://getkong.org/community/ to include community tools from [KONG Readme](https://github.com/Mashape/kong/blob/master/README.md#community-resources-and-tools) as per issue #141.

Final appearance:
![image](https://cloud.githubusercontent.com/assets/12798751/15797738/0070f0ba-29f0-11e6-840e-2e5dab17eabe.png)
