### PR TITLE
feat(community): add Kong Toronto to Meetup list

### DIFF
--- a/app/community/index.html
+++ b/app/community/index.html
@@ -67,26 +67,29 @@ community_tools:
     website: https://www.nuget.org/packages/Kong/0.0.4
     
 community_meetups:
-  - name: Kong San Francisco
-    website: http://www.meetup.com/Kong-SF/
-  
-  - name: Kong Boston
-    website: http://www.meetup.com/Kong-BOSTON/
-    
-  - name: Kong London
-    website: http://www.meetup.com/Kong-LONDON/
-    
-  - name: Kong Detroit
-    website: http://www.meetup.com/Kong-DETROIT/
-    
-  - name: Kong New York
-    website: http://www.meetup.com/Kong-NY/
-    
   - name: Kong Amsterdam
     website: http://www.meetup.com/Kong-AMSTERDAM/
-    
+
+  - name: Kong Boston
+    website: http://www.meetup.com/Kong-BOSTON/
+
+  - name: Kong Detroit
+    website: http://www.meetup.com/Kong-DETROIT/
+
+  - name: Kong London
+    website: http://www.meetup.com/Kong-LONDON/
+
+  - name: Kong New York
+    website: http://www.meetup.com/Kong-NY/
+
+  - name: Kong San Francisco
+    website: http://www.meetup.com/Kong-SF/
+
   - name: Kong Tokyo
     website: http://www.meetup.com/Kong-TOKYO
+
+  - name: Kong Toronto
+    website: http://www.meetup.com/Kong-toronto/
 ---
 
 <div class="page page-community">


### PR DESCRIPTION
Include the new Kong Toronto meetup and alphabetise Meetup list on https://getkong.org/community/ as such:

![image](https://cloud.githubusercontent.com/assets/12798751/15842354/4a5298b8-2c26-11e6-9797-9174213fdf0d.png)
