### PR TITLE
feat(enterprise): remove production support features

### DIFF
--- a/app/enterprise/index.html
+++ b/app/enterprise/index.html
@@ -70,9 +70,6 @@ redirect_from: /support/
           <li class="plan-line">Email, Chat &amp; Phone Support with Kong Engineers</li>
           <li class="plan-line">30 Mins to 8 Hours Response Times</li>
           <li class="plan-line">25 to Unlimited Max Annual Incidents</li>
-          <li class="plan-line">Initial Setup</li>
-          <li class="plan-line">Migration from 3rd party API Management Tools</li>
-          <li class="plan-line">High Availability Best Practices</li>
           <li class="plan-line">Hot Fixes and Emergency Patches</li>
           <li class="plan-line muted">
             <h5>Consulting and Training (optional)</h5>


### PR DESCRIPTION
Removes three lines from Kong Enterprise Subscription column's "Official Production Support" set as outlined in #240.

![image](https://cloud.githubusercontent.com/assets/12798751/15844102/6e48132e-2c35-11e6-9e2f-3ce52e90fc26.png)
