### PR TITLE
feat(markt) new Kong Cloud landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This folder is the source code for [Kong](https://github.com/Mashape/kong)'s web
 
 - [npm](https://www.npmjs.com/)
 - [Bundler](http://bundler.io/)
-- [Ruby](https://www.ruby-lang.org) (>= 2.0, < 2.3)
-- [Python](https://www.python.org) (>= 2.7.X, < 3)
+- [Ruby](https://www.ruby-lang.org) `(>= 2.0, < 2.3)`
+- [Python](https://www.python.org) `(>= 2.7.X, < 3)`
 
 ## Install
 

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -162,6 +162,27 @@ $(function () {
     analytics.identify(email, traits, track)
   })
 
+  // Cloud page demo request Typeform
+
+  var expandTypeform = function () {
+    $('#enterprise').slideUp(600, function() {
+      // $('#typeform').addClass('expand-typeform')
+      var subtractHeight = $('.site-header').height() + $('.footer').height()
+      $('#typeform')
+        .css('height', 'calc(100vh - ' + subtractHeight + 'px)')
+    })
+  }
+
+  $('#start-typeform').one('click', function (e) {
+    e.preventDefault()
+    expandTypeform()
+  })
+
+  $('#typeform-clickzone').one('click', function() {
+    expandTypeform()
+    $(this).addClass('clicked')
+  })
+
   // Enterprise page demo request form
 
   $('.demo-request-form').on('submit', function (e) {

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -166,7 +166,6 @@ $(function () {
 
   var expandTypeform = function () {
     $('#enterprise').slideUp(600, function() {
-      // $('#typeform').addClass('expand-typeform')
       var subtractHeight = $('.site-header').height() + $('.footer').height()
       $('#typeform')
         .css('height', 'calc(100vh - ' + subtractHeight + 'px)')

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -162,26 +162,6 @@ $(function () {
     analytics.identify(email, traits, track)
   })
 
-  // Cloud page demo request Typeform
-
-  var expandTypeform = function () {
-    $('#typeform-clickzone').addClass('clicked')
-    $('#enterprise').slideUp(600, function () {
-      var subtractHeight = $('.site-header').height() + $('.footer').height()
-      $('#typeform')
-        .css('height', 'calc(100vh - ' + subtractHeight + 'px)')
-    })
-  }
-
-  $('#start-typeform').one('click', function (e) {
-    e.preventDefault()
-    expandTypeform()
-  })
-
-  $('#typeform-clickzone').one('click', function () {
-    expandTypeform()
-  })
-
   // Enterprise page demo request form
 
   $('.demo-request-form').on('submit', function (e) {

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -165,7 +165,7 @@ $(function () {
   // Cloud page demo request Typeform
 
   var expandTypeform = function () {
-    $('#enterprise').slideUp(600, function() {
+    $('#enterprise').slideUp(600, function () {
       var subtractHeight = $('.site-header').height() + $('.footer').height()
       $('#typeform')
         .css('height', 'calc(100vh - ' + subtractHeight + 'px)')
@@ -177,7 +177,7 @@ $(function () {
     expandTypeform()
   })
 
-  $('#typeform-clickzone').one('click', function() {
+  $('#typeform-clickzone').one('click', function () {
     expandTypeform()
     $(this).addClass('clicked')
   })

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -165,6 +165,7 @@ $(function () {
   // Cloud page demo request Typeform
 
   var expandTypeform = function () {
+    $('#typeform-clickzone').addClass('clicked')
     $('#enterprise').slideUp(600, function () {
       var subtractHeight = $('.site-header').height() + $('.footer').height()
       $('#typeform')
@@ -179,7 +180,6 @@ $(function () {
 
   $('#typeform-clickzone').one('click', function () {
     expandTypeform()
-    $(this).addClass('clicked')
   })
 
   // Enterprise page demo request form

--- a/app/_assets/stylesheets/pages/enterprise.less
+++ b/app/_assets/stylesheets/pages/enterprise.less
@@ -4,7 +4,7 @@
   font-size: 18px;
   line-height: 32px;
   padding: 0;
-
+  
   .column {
     height: 350px;
     position: relative;
@@ -183,5 +183,44 @@
     text-align: center;
     font-weight: 500;
     margin-bottom: 80px;
+  }
+}
+
+/*
+** Request a Demo Page (Typeform embed)
+*/
+
+.typeform-body {
+  position: relative;
+  width: 100%;
+  height: ~"calc(100vh - 510px)";
+  min-height: 400px;
+  background-color: #002038;
+  transition: height 0.6s ease;
+
+  &.expand-typeform {
+    height: ~"calc(100vh - 160px)";
+  }
+
+  .typeform-form-wrap {
+    position: relative;
+    width: 100%;
+    height: 100%;
+
+    .clickzone {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+
+      &.clicked {
+        display: none;
+      }
+    }
+
+    iframe {
+      height: 100%;
+    }
   }
 }

--- a/app/_assets/stylesheets/pages/enterprise.less
+++ b/app/_assets/stylesheets/pages/enterprise.less
@@ -187,36 +187,32 @@
 }
 
 /*
-** Request a Demo Page (Typeform embed)
+** Kong Cloud
 */
 
-.typeform-body {
-  position: relative;
-  width: 100%;
-  height: ~"calc(100vh - 510px)";
-  min-height: 400px;
-  background-color: #002038;
-  transition: height 0.6s ease;
+body#cloud {
+  min-height: 100vh;
+  margin-bottom: 0;
 
-  .typeform-form-wrap {
-    position: relative;
-    width: 100%;
-    height: 100%;
+  @media (min-width: 990px) {
+    min-height: ~"calc(100vh - 107px)";
+  }
 
-    .clickzone {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      top: 0;
-      left: 0;
+  .enterprise-section {
+    height: ~"calc(100vh - 300px)";
+    min-height: 400px;
 
-      &.clicked {
-        display: none;
-      }
+    @media (min-width: 490px) {
+      height: ~"calc(100vh - 150px)";
     }
 
-    iframe {
-      height: 100%;
+    @media (min-width: 990px) {
+      height: auto;
+      min-height: 0;
     }
+  }
+
+  .footer {
+    bottom: 0;
   }
 }

--- a/app/_assets/stylesheets/pages/enterprise.less
+++ b/app/_assets/stylesheets/pages/enterprise.less
@@ -198,10 +198,6 @@
   background-color: #002038;
   transition: height 0.6s ease;
 
-  &.expand-typeform {
-    height: ~"calc(100vh - 160px)";
-  }
-
   .typeform-form-wrap {
     position: relative;
     width: 100%;

--- a/app/_assets/stylesheets/pages/enterprise.less
+++ b/app/_assets/stylesheets/pages/enterprise.less
@@ -199,15 +199,10 @@ body#cloud {
   }
 
   .enterprise-section {
-    height: ~"calc(100vh - 300px)";
+    height: ~"calc(100vh - 110px)";
     min-height: 400px;
 
-    @media (min-width: 490px) {
-      height: ~"calc(100vh - 150px)";
-    }
-
     @media (min-width: 990px) {
-      height: auto;
       min-height: 0;
     }
   }

--- a/app/_assets/stylesheets/pages/enterprise.less
+++ b/app/_assets/stylesheets/pages/enterprise.less
@@ -4,7 +4,7 @@
   font-size: 18px;
   line-height: 32px;
   padding: 0;
-  
+
   .column {
     height: 350px;
     position: relative;

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -31,6 +31,7 @@
           <li><a href="/plugins/" {% if page.url == "/plugins/" %} class="active"{% endif %}>Plugins</a></li>
           <li><a href="/community/" {% if page.url == "/community/" %} class="active"{% endif %}>Community</a></li>
           <li><a href="https://www.mashape.com/enterprise/">Enterprise</a></li>
+           <li><a href="/cloud/" {% if page.url == "/cloud/" %} class="active"{% endif %}>Cloud</a></li>
           <li><a href="{{ site.repos.kong }}" target="_blank">GitHub</a></li>
           <li>
             <a href="/install/" class="button button-dark{% if page.url == "/install/" %} active{% endif %}" data-analytics='{"event": "Clicked download", "type": "button", "location": "header"}'>Installation</a>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -31,7 +31,7 @@
           <li><a href="/plugins/" {% if page.url == "/plugins/" %} class="active"{% endif %}>Plugins</a></li>
           <li><a href="/community/" {% if page.url == "/community/" %} class="active"{% endif %}>Community</a></li>
           <li><a href="https://www.mashape.com/enterprise/">Enterprise</a></li>
-           <li><a href="/cloud/" {% if page.url == "/cloud/" %} class="active"{% endif %}>Cloud</a></li>
+          <li><a href="/cloud/" {% if page.url == "/cloud/" %} class="active"{% endif %}>Cloud</a></li>
           <li><a href="{{ site.repos.kong }}" target="_blank">GitHub</a></li>
           <li>
             <a href="/install/" class="button button-dark{% if page.url == "/install/" %} active{% endif %}" data-analytics='{"event": "Clicked download", "type": "button", "location": "header"}'>Installation</a>

--- a/app/cloud/index.html
+++ b/app/cloud/index.html
@@ -5,14 +5,14 @@ hide_subscribe: true
 id: cloud
 ---
 
-<section class="section enterprise-section">
+<section id="enterprise" class="section enterprise-section">
   <div class="container">
     <div class="row">
       <div class="one-half column">
         <h2>The Power of Kong, now delivered SaaS</h2>
         <p>Kong Cloud comes with high-performance hosting, SLA, Backups, HA, 24x7 Support and more.</p>
         <p>
-          <a href="#request-demo" class="button button-primary button-large scroll-to">Request Demo</a>
+          <a href="#" id="start-typeform" class="button button-primary button-large">Request Demo</a>
         </p>
       </div>
       <div class="one-half column">
@@ -24,48 +24,10 @@ id: cloud
   </div>
 </section>
 
-<section class="section demo-request-section" id="request-demo">
-  <div class="container">
-    <header class="section-header">
-      <h2>START YOUR KONG CLOUD</h2>
-      <p>You're Just a Few Clicks Away</p>
-    </header>
-
-    <form class="demo-request-form">
-      <div class="spinner">
-        <div class="bounce1"></div>
-        <div class="bounce2"></div>
-        <div class="bounce3"></div>
-      </div>
-
-      <div class="alert alert-success" role="alert"><center>Thank you! We'll be in touch soon.</center></div>
-
-      <div class="input-group">
-
-        <label for="company-name">Company Name</label>
-        <input id="company-name" name="company" type="text" placeholder="Mashape Inc" required>
-
-        <label for="full-name">Full Name</label>
-        <input id="full-name" name="name" type="text" placeholder="Jason Businessman" required>
-
-        <label for="title">Title</label>
-        <input id="title" name="title" type="text" placeholder="CEO">
-
-        <label for="work-email">Work Email</label>
-        <input id="work-email" name="email" type="email" placeholder="jason@mashape.com" required>
-
-        <label for="phone">Phone <small>(optional)</small></label>
-        <input id="phone" name="phone" type="text" placeholder="415 000 0000">
-
-        <label for="tell-us-more">Tell us more</label>
-        <textarea name="tell_us_more" id="tell-us-more" cols="30" rows="5"></textarea>
-
-        <button type="submit" class="button button-primary button-large u-full-width">Send Request</button>
-      </div>
-
-      <figure>
-        <img src="/assets/images/enterprise/enterprise-footer.svg" width="440" height="81" alt="Enterprise"/>
-      </figure>
-    </form>
+<section id="typeform" class="typeform-body">
+  <div class="typeform-form-wrap">
+    <div id="typeform-clickzone" class="clickzone"></div>
+    <iframe id="tf-form" designMode="on" onload="this.contentWindow.focus()" width="100%" height="100%" frameborder="0" src="https://mashape.typeform.com/to/QeVPLT"></iframe>
+  <script type="text/javascript" src="https://s3-eu-west-1.amazonaws.com/share.typeform.com/embed.js"></script>
   </div>
 </section>

--- a/app/cloud/index.html
+++ b/app/cloud/index.html
@@ -12,7 +12,7 @@ id: cloud
         <h2>The Power of Kong, now delivered SaaS</h2>
         <p>Kong Cloud comes with high-performance hosting, SLA, Backups, HA, 24x7 Support and more.</p>
         <p>
-          <a href="https://mashape.typeform.com/to/QeVPLT" id="start-typeform" class="button button-primary button-large typeform-share link" data-mode="2">Request Demo</a>
+          <a href="https://mashape.com/enterprise/" class="button button-primary button-large typeform-share link" data-mode="2">Request Demo</a>
         </p>
       </div>
       <div class="one-half column">
@@ -23,5 +23,3 @@ id: cloud
     </div>
   </div>
 </section>
-
-<script>(function(){var qs,js,q,s,d=document,gi=d.getElementById,ce=d.createElement,gt=d.getElementsByTagName,id='typef_orm',b='https://s3-eu-west-1.amazonaws.com/share.typeform.com/';if(!gi.call(d,id)){js=ce.call(d,'script');js.id=id;js.src=b+'share.js';q=gt.call(d,'script')[0];q.parentNode.insertBefore(js,q)}})()</script>

--- a/app/cloud/index.html
+++ b/app/cloud/index.html
@@ -1,0 +1,80 @@
+---
+title: Kong Cloud
+layout: default
+hide_subscribe: true
+id: cloud
+---
+
+<section class="section enterprise-section">
+  <div class="container">
+    <div class="row">
+      <div class="one-half column">
+        <h2>The Power of Kong, now delivered SaaS</h2>
+        <p>Kong Cloud comes with high performance, SLA, Backups, HA, 24x7 Support and more.</p>
+        <p>
+          <a href="#request-demo" class="button button-primary button-large scroll-to">Request Demo</a>
+        </p>
+      </div>
+      <div class="one-half column">
+        <figure>
+          <img src="/assets/images/enterprise/enterprise.svg" width="440" height="222" alt="Enterprise"/>
+        </figure>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section demo-request-section" id="request-demo">
+  <div class="container">
+    <header class="section-header">
+      <h2>You're Just a Few Clicks Away from Starting Your Kong Cloud</h2>
+    </header>
+
+    <form class="demo-request-form">
+      <div class="spinner">
+        <div class="bounce1"></div>
+        <div class="bounce2"></div>
+        <div class="bounce3"></div>
+      </div>
+
+      <div class="alert alert-success" role="alert"><center>Thank you! We'll be in touch soon.</center></div>
+
+      <div class="input-group">
+
+        <label for="company-name">Company Name</label>
+        <input id="company-name" name="company" type="text" placeholder="Mashape Inc" required>
+
+        <label for="full-name">Full Name</label>
+        <input id="full-name" name="name" type="text" placeholder="Jason Businessman" required>
+
+        <label for="title">Title</label>
+        <input id="title" name="title" type="text" placeholder="CEO">
+
+        <label for="work-email">Work Email</label>
+        <input id="work-email" name="email" type="email" placeholder="jason@mashape.com" required>
+
+        <label for="phone">Phone <small>(optional)</small></label>
+        <input id="phone" name="phone" type="text" placeholder="415 000 0000">
+
+        <label for="tell-us-more">Tell us more</label>
+        <textarea name="tell_us_more" id="tell-us-more" cols="30" rows="5"></textarea>
+
+        <div class="choose-deploy-type row">
+          <label class="one-half column">
+            <input type="radio" name="deployment" value="on-prem" checked/> On-Prem Deployment
+          </label>
+
+          <label class="one-half column">
+            <input type="radio" name="deployment" value="cloud"/> Cloud Deployment
+          </label>
+        </div>
+
+        <button type="submit" class="button button-primary button-large u-full-width">Send Request</button>
+      </div>
+
+      <figure>
+        <img src="/assets/images/enterprise/enterprise-footer.svg" width="440" height="81" alt="Enterprise"/>
+      </figure>
+    </form>
+  </div>
+</section>

--- a/app/cloud/index.html
+++ b/app/cloud/index.html
@@ -10,7 +10,7 @@ id: cloud
     <div class="row">
       <div class="one-half column">
         <h2>The Power of Kong, now delivered SaaS</h2>
-        <p>Kong Cloud comes with high performance, SLA, Backups, HA, 24x7 Support and more.</p>
+        <p>Kong Cloud comes with high-performance hosting, SLA, Backups, HA, 24x7 Support and more.</p>
         <p>
           <a href="#request-demo" class="button button-primary button-large scroll-to">Request Demo</a>
         </p>
@@ -27,7 +27,8 @@ id: cloud
 <section class="section demo-request-section" id="request-demo">
   <div class="container">
     <header class="section-header">
-      <h2>You're Just a Few Clicks Away from Starting Your Kong Cloud</h2>
+      <h2>START YOUR KONG CLOUD</h2>
+      <p>You're Just a Few Clicks Away</p>
     </header>
 
     <form class="demo-request-form">
@@ -58,16 +59,6 @@ id: cloud
 
         <label for="tell-us-more">Tell us more</label>
         <textarea name="tell_us_more" id="tell-us-more" cols="30" rows="5"></textarea>
-
-        <div class="choose-deploy-type row">
-          <label class="one-half column">
-            <input type="radio" name="deployment" value="on-prem" checked/> On-Prem Deployment
-          </label>
-
-          <label class="one-half column">
-            <input type="radio" name="deployment" value="cloud"/> Cloud Deployment
-          </label>
-        </div>
 
         <button type="submit" class="button button-primary button-large u-full-width">Send Request</button>
       </div>

--- a/app/cloud/index.html
+++ b/app/cloud/index.html
@@ -12,7 +12,7 @@ id: cloud
         <h2>The Power of Kong, now delivered SaaS</h2>
         <p>Kong Cloud comes with high-performance hosting, SLA, Backups, HA, 24x7 Support and more.</p>
         <p>
-          <a href="#" id="start-typeform" class="button button-primary button-large">Request Demo</a>
+          <a href="https://mashape.typeform.com/to/QeVPLT" id="start-typeform" class="button button-primary button-large typeform-share link" data-mode="2">Request Demo</a>
         </p>
       </div>
       <div class="one-half column">
@@ -24,10 +24,4 @@ id: cloud
   </div>
 </section>
 
-<section id="typeform" class="typeform-body">
-  <div class="typeform-form-wrap">
-    <div id="typeform-clickzone" class="clickzone"></div>
-    <iframe id="tf-form" designMode="on" onload="this.contentWindow.focus()" width="100%" height="100%" frameborder="0" src="https://mashape.typeform.com/to/QeVPLT"></iframe>
-  <script type="text/javascript" src="https://s3-eu-west-1.amazonaws.com/share.typeform.com/embed.js"></script>
-  </div>
-</section>
+<script>(function(){var qs,js,q,s,d=document,gi=d.getElementById,ce=d.createElement,gt=d.getElementsByTagName,id='typef_orm',b='https://s3-eu-west-1.amazonaws.com/share.typeform.com/';if(!gi.call(d,id)){js=ce.call(d,'script');js.id=id;js.src=b+'share.js';q=gt.call(d,'script')[0];q.parentNode.insertBefore(js,q)}})()</script>

--- a/app/enterprise/index.html
+++ b/app/enterprise/index.html
@@ -57,7 +57,6 @@ redirect_from: /support/
             <h4>Kong Enterprise Subscription</h4>
           </li>
           <li class="plan-line muted">
-
             <h5>Products</h5>
           </li>
           <li class="plan-line"><a href="http://www.getgalileo.io" target="_blank">Galileo</a> - API Analytics</li>


### PR DESCRIPTION
New Kong Cloud landing page as discussed in #232:
- 'Cloud' link in header navigation
- Hero area text
- Standard 'request demo' form on page
- 'On-Premise Deployment' and 'Cloud Deployment' options removed in form
- Update README formatting

**See inline comments for special notes.**

![image](https://cloud.githubusercontent.com/assets/12798751/15983045/313f6c8e-2f69-11e6-8b4c-6dc253eb0bef.png)
![image](https://cloud.githubusercontent.com/assets/12798751/15983048/3b9bc0c4-2f69-11e6-9932-a61d17f9e1cb.png)
