### PR TITLE
feat(links): change demo links to new enterprise page

### DIFF
--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -36,6 +36,7 @@
           line-height: 1.2;
           font-weight: 600;
           color: rgba(255, 255, 255, 0.55);
+          text-transform: uppercase;
 
           &:hover,
           &:focus {
@@ -59,7 +60,7 @@
 
     .enterprise-sites {
       li {
-        margin-right: 1.8rem;
+        margin-right: 1.1875rem;
 
         &:last-child {
           margin: 0;

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -28,7 +28,7 @@
         <a href="/license">License</a>
         <a href="/terms">Terms</a>
         <a href="/privacy">Privacy</a>
-        <a href="/enterprise">Enterprise</a>
+        <a href="https://www.mashape.com/enterprise/">Enterprise</a>
         <a href="http://blog.mashape.com/category/open-source/" target="_blank">News</a>
       </span>
     </div>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -6,12 +6,12 @@
           <li class="active"><a href="http://getkong.org">Kong</a></li>
           <li><a href="http://gelato.io">Gelato</a></li>
           <li><a href="http://getgalileo.io">Galileo</a></li>
-          <li><a href="http://market.mashape.com">Marketplace</a></li>
+          <li><a href="http://www.mashape.com/enterprise/">Enterprise</a></li>
         </ul>
       </nav>
       <nav class="enterprise-contact one-half column">
         <ul>
-          <li><a href="https://www.mashape.com/request-demo/">Request Demo</a></li>
+          <li><a href="https://www.mashape.com/enterprise/#demo-form">Request Demo</a></li>
           <li><a href="tel:+18664021473">Sales: +1 (866) 402-1473</a></li>
         </ul>
       </nav>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -30,7 +30,7 @@
           <li><a href="/docs/" {% if page.url contains "/docs/" %} class="active"{% endif %}>Docs</a></li>
           <li><a href="/plugins/" {% if page.url == "/plugins/" %} class="active"{% endif %}>Plugins</a></li>
           <li><a href="/community/" {% if page.url == "/community/" %} class="active"{% endif %}>Community</a></li>
-          <li><a href="/enterprise/" {% if page.url == "/enterprise/" %} class="active"{% endif %}>Enterprise</a></li>
+          <li><a href="https://www.mashape.com/enterprise/">Enterprise</a></li>
           <li><a href="{{ site.repos.kong }}" target="_blank">GitHub</a></li>
           <li>
             <a href="/install/" class="button button-dark{% if page.url == "/install/" %} active{% endif %}" data-analytics='{"event": "Clicked download", "type": "button", "location": "header"}'>Installation</a>

--- a/app/enterprise/index.html
+++ b/app/enterprise/index.html
@@ -13,7 +13,7 @@ redirect_from: /support/
         <h2>Kong for Modern Enterprises</h2>
         <p>Multi-datacenter deployments, Kong Manager, Analytics, Dev Portal, Professional Support and More.</p>
         <p>
-          <a href="#request-demo" class="button button-primary button-large scroll-to">Request Demo</a>
+          <a href="https://www.mashape.com/enterprise/#demo-form" class="button button-primary button-large">Request Demo</a>
         </p>
       </div>
       <div class="one-half column">
@@ -80,66 +80,10 @@ redirect_from: /support/
           <li class="plan-line">API Certifications</li>
           <li class="plan-line">Security Audit</li>
           <li>
-            <a href="#request-demo" class="plan-line success scroll-to">TALK TO KONG EXPERTS!</a>
+            <a href="https://www.mashape.com/enterprise/#demo-form" class="plan-line success">TALK TO KONG EXPERTS!</a>
           </li>
         </ul>
       </div>
     </div>
-  </div>
-</section>
-
-<section class="section demo-request-section" id="request-demo">
-  <div class="container">
-    <header class="section-header">
-      <h2>TALK TO KONG EXPERTS!</h2>
-      <p>Take 15 minutes to learn more about Kong.</p>
-    </header>
-
-    <form class="demo-request-form">
-      <div class="spinner">
-        <div class="bounce1"></div>
-        <div class="bounce2"></div>
-        <div class="bounce3"></div>
-      </div>
-
-      <div class="alert alert-success" role="alert"><center>Thank you! We'll be in touch soon.</center></div>
-
-      <div class="input-group">
-
-        <label for="company-name">Company Name</label>
-        <input id="company-name" name="company" type="text" placeholder="Mashape Inc" required>
-
-        <label for="full-name">Full Name</label>
-        <input id="full-name" name="name" type="text" placeholder="Jason Businessman" required>
-
-        <label for="title">Title</label>
-        <input id="title" name="title" type="text" placeholder="CEO">
-
-        <label for="work-email">Work Email</label>
-        <input id="work-email" name="email" type="email" placeholder="jason@mashape.com" required>
-
-        <label for="phone">Phone <small>(optional)</small></label>
-        <input id="phone" name="phone" type="text" placeholder="415 000 0000">
-
-        <label for="tell-us-more">Tell us more</label>
-        <textarea name="tell_us_more" id="tell-us-more" cols="30" rows="5"></textarea>
-
-        <div class="choose-deploy-type row">
-          <label class="one-half column">
-            <input type="radio" name="deployment" value="on-prem" checked/> On-Prem Deployment
-          </label>
-
-          <label class="one-half column">
-            <input type="radio" name="deployment" value="cloud"/> Cloud Deployment
-          </label>
-        </div>
-
-        <button type="submit" class="button button-primary button-large u-full-width">Send Request</button>
-      </div>
-
-      <figure>
-        <img src="/assets/images/enterprise/enterprise-footer.svg" width="440" height="81" alt="Enterprise"/>
-      </figure>
-    </form>
   </div>
 </section>


### PR DESCRIPTION
Change all request demo links to direct to mashape.com/enterprise

1) Add new mashape.com/enterprise product link in header
2) Update links in getkong.org/enterprise to new enterprise page (request demo, and talk to kong experts)
3) Remove form in getkong.org/enterprise
4) Reduce product links' margin in header
5) Remove link to 'Marketplace' in header
6) Make product links in header uppercase

## To Discuss

![image](https://cloud.githubusercontent.com/assets/12798751/17873311/cf207882-6892-11e6-9a46-855e3ed88fa2.png)

1) This link has not changed, should it? @sinzone 
2) This link directs to mashape.com/enterprise

![image](https://cloud.githubusercontent.com/assets/12798751/17873361/2fdabf20-6893-11e6-8af0-3abcbb29445f.png)

3) This form will be removed with this PR