### PR TITLE
Fix OAuth2 example of use Refresh Token to get a new access token

### DIFF
--- a/app/plugins/oauth2-authentication.md
+++ b/app/plugins/oauth2-authentication.md
@@ -276,13 +276,13 @@ In this flow, the steps that you need to implement are:
 
 When your access token expires, you can generate a new access token using the refresh token you received in conjunction to your expired access token.
 
-    ```bash
-    $ curl -X POST https://your.api.com/oauth2/token \ 
-        --data "grant_type=refresh_token" \
-        --data "client_id=XXX" \
-        --data "client_secret=XXX" \
-        --data "refresh_token=XXX"
-    ```
+```bash
+$ curl -X POST https://your.api.com/oauth2/token \
+    --data "grant_type=refresh_token" \
+    --data "client_id=XXX" \
+    --data "client_secret=XXX" \
+    --data "refresh_token=XXX"
+```
 
 [ssl-plugin]: /plugins/dynamic-ssl/
 [api-object]: /docs/latest/admin-api/#api-object


### PR DESCRIPTION
Fix the markdown spaces in the OAuth2 example of use Refresh Token to get a new access token. 
