### PR TITLE
docs(config) 0.9.x: clarify purpose of cluster_listen_rpc

### DIFF
--- a/app/docs/0.9.x/configuration.md
+++ b/app/docs/0.9.x/configuration.md
@@ -458,8 +458,8 @@ Default: `0.0.0.0:7946`
 
 ##### **cluster_listen_rpc**
 
-Address and port used by this node to communicate with the cluster.
-Only contains TCP traffic over the local network.
+Address and port used to communicate with the cluster through the agent
+running on this node. Only contains TCP traffic local to this node.
 
 Default: `127.0.0.1:7373`
 


### PR DESCRIPTION
### Summary

In the docs for 0.9.x, clarify purpose of cluster_listen_rpc configuration parameter.

### Full changelog

* docs/0.9.x/configuration.md: clarify purpose of cluster_listen_rpc

As a new kong user, I was unsure of the purpose of cluster_listen_rpc from reading the 0.9.x docs. After reading through the code, I'd like to submit this to make that clearer for other new users.

This relates to PR https://github.com/Mashape/kong/pull/1860 to update the same explanation in kong.conf.default.

Thank you for your time.