### PR TITLE
docs(acl) Fix link to faq-authentication

### DIFF
--- a/app/plugins/acl.md
+++ b/app/plugins/acl.md
@@ -71,4 +71,4 @@ When a consumer has been validated, the plugin will append a `X-Consumer-Groups`
 [api-object]: /docs/latest/admin-api/#api-object
 [configuration]: /docs/latest/configuration
 [consumer-object]: /docs/latest/admin-api/#consumer-object
-[faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?
+[faq-authentication]: /about/faq/#how-can-i-add-authentication-to-a-microservice-api


### PR DESCRIPTION
acl.md: Fix broken link to FAQ entry

Fixes broken link at https://getkong.org/plugins/acl/ at "authentication plugin" into the FAQ:

\- https://getkong.org/about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?
\+ https://getkong.org/about/faq/#how-can-i-add-authentication-to-a-microservice-api