### PR TITLE
docs: Mention ACL plugin in related authentication docs: FAQ, key-authentication, basic-authentication

### DIFF
--- a/app/about/faq.md
+++ b/app/about/faq.md
@@ -216,6 +216,9 @@ like the [Basic Authentication](/plugins/basic-authentication/), [Key
 Authentication](/plugins/key-authentication/) and [OAuth
 2.0](/plugins/oauth2-authentication/) plugins.
 
+To restrict usage of a service to only some of the authenticated users, add the
+[ACL](/plugins/acl/) plugin and create whitelist or blacklist groups of users.
+
 ----
 
 ## How can I migrate to Kong from another API Gateway?

--- a/app/plugins/basic-authentication.md
+++ b/app/plugins/basic-authentication.md
@@ -34,6 +34,11 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 
 You can also apply it for every API using the `http://kong:8001/plugins/` endpoint. Read the [Plugin Reference](/docs/latest/admin-api/#add-plugin) for more information.
 
+Once applied, any user with a valid credential can access the service/API.
+To restrict usage to only some of the authenticated users, also add the
+[ACL](/plugins/acl/) plugin (not covered here) and create whitelist or
+blacklist groups of users.
+
 form parameter                             | default | description
 ---                                        | ---     | ---
 `name`                                     |         | The name of the plugin to use, in this case: `basic-auth`
@@ -59,6 +64,10 @@ parameter                       | default | description
 `custom_id`<br>*semi-optional*  |         | A custom identifier used to map the consumer to another database. Either this field or `username` must be specified.
 
 A [Consumer][consumer-object] can have many credentials.
+
+If you are also using the [ACL](/plugins/acl/) plugin and whitelists with this
+service, you must add the new consumer to a whitelisted group. See
+[ACL: Associating Consumers][acl-associating] for details.
 
 ### Create a Credential
 
@@ -91,4 +100,5 @@ You can use this information on your side to implement additional logic. You can
 [api-object]: /docs/latest/admin-api/#api-object
 [configuration]: /docs/latest/configuration
 [consumer-object]: /docs/latest/admin-api/#consumer-object
+[acl-associating]: /plugins/acl/#associating-consumers
 [faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?

--- a/app/plugins/key-authentication.md
+++ b/app/plugins/key-authentication.md
@@ -57,6 +57,11 @@ HTTP/1.1 201 Created
 
 You can also apply it for every API using the `http://kong:8001/plugins/` endpoint. Read the [Plugin Reference](/docs/latest/admin-api/#add-plugin) for more information.
 
+Once applied, any user with a valid credential can access the service/API.
+To restrict usage to only some of the authenticated users, also add the
+[ACL](/plugins/acl/) plugin (not covered here) and create whitelist or
+blacklist groups of users.
+
 form parameter                   | default | description
 ---                              | ---     | ---               
 `name`                           |         | The name of the plugin to use, in this case: `key-auth`.
@@ -93,6 +98,10 @@ parameter                      | default | description
 `custom_id`<br>*semi-optional* |         | A custom identifier used to map the Consumer to another database. Either this field or `username` must be specified.
 
 A [Consumer][consumer-object] can have many credentials.
+
+If you are also using the [ACL](/plugins/acl/) plugin and whitelists with this
+service, you must add the new consumer to a whitelisted group. See
+[ACL: Associating Consumers][acl-associating] for details.
 
 ### Create an API Key
 
@@ -148,4 +157,5 @@ You can use this information on your side to implement additional logic. You can
 [api-object]: /docs/latest/admin-api/#api-object
 [configuration]: /docs/latest/configuration
 [consumer-object]: /docs/latest/admin-api/#consumer-object
+[acl-associating]: /plugins/acl/#associating-consumers
 [faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?


### PR DESCRIPTION
Mention the ACL plugin in related authentication docs (FAQ, key-authentication, basic-authentication), and clarify that by default the auth plugins grant access to all consumers authenticated with that plugin.

If I'm mistaken there, please let me know.

Thank you for your time.