### PR TITLE
fix(docs): bring back version dropdown

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -77,18 +77,6 @@
   lua_doc: true
 -
   release: "0.9.x"
-  version: "0.9.5"
-  luarocks_version: "0.9.5-0"
-  dependencies:
-    luajit: "2.1.0-alpha"
-    luarocks: "2.3.0"
-    cassandra: "2.2.x"
-    postgres: "9.4+"
-    openresty: "1.9.15.1"
-    serf: "0.7"
-  lua_doc: true
--
-  release: "0.9.x"
   version: "0.9.9"
   luarocks_version: "0.9.8-0"
   dependencies:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ var sources = {
   content: 'app/**/*.{markdown,md,html,txt,yml,yaml}',
   styles: paths.assets + 'stylesheets/**/*',
   js: [
-    paths.assets + 'javascripts/**/*.js',
+    paths.assets + 'javascripts/app.js',
     paths.modules + 'bootstrap/js/dropdown.js',
     paths.modules + 'bootstrap/js/affix.js'
   ],
@@ -45,8 +45,7 @@ gulp.task('styles', function () {
 gulp.task('javascripts', function () {
   return gulp.src(sources.js)
     .pipe($.plumber())
-    .pipe($.sourcemaps.init())
-    .pipe($.sourcemaps.write('maps'))
+    .pipe($.concat('app.js'))
     .pipe(gulp.dest('dist/assets'))
     .pipe($.size())
     .pipe(browserSync.stream())


### PR DESCRIPTION
Bring back the missing version dropdown menu.

<img width="223" alt="screen shot 2017-02-27 at 7 25 08 pm" src="https://cloud.githubusercontent.com/assets/12798751/23386100/84273846-fd22-11e6-95d8-e6db987714cb.png">
