### PR TITLE
doc(plugins) sync logging plugin docs

### DIFF
--- a/app/plugins/file-log.md
+++ b/app/plugins/file-log.md
@@ -79,16 +79,24 @@ Every request will be logged separately in a JSON object separated by a new line
     },
     "authenticated_entity": {
         "consumer_id": "80f74eef-31b8-45d5-c525-ae532297ea8e",
-        "created_at":	1437643103000,
         "id": "eaa330c0-4cff-47f5-c79e-b2e4f355207e",
-        "key": "2b64e2f0193851d4135a2e885cd08a65"
     },
     "api": {
-        "request_host": "test.com",
-        "upstream_url": "http://mockbin.org/",
-        "created_at": 1432855823000,
-        "name": "test.com",
-        "id": "fbaf95a1-cd04-4bf6-cb73-6cb3285fef58"
+        "created_at": 1488830759000,
+        "hosts": [
+          "example.org"
+        ],
+        "http_if_terminated": true,
+        "https_only": false,
+        "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+        "name": "example-api",
+        "preserve_host": false,
+        "retries": 5,
+        "strip_uri": true,
+        "upstream_connect_timeout": 60000,
+        "upstream_read_timeout": 60000,
+        "upstream_send_timeout": 60000,
+        "upstream_url": "http://httpbin.org"
     },
     "latencies": {
         "proxy": 1430,

--- a/app/plugins/http-log.md
+++ b/app/plugins/http-log.md
@@ -85,16 +85,24 @@ Every request will be logged separately in a JSON object, with the following for
     },
     "authenticated_entity": {
         "consumer_id": "80f74eef-31b8-45d5-c525-ae532297ea8e",
-        "created_at":	1437643103000,
         "id": "eaa330c0-4cff-47f5-c79e-b2e4f355207e",
-        "key": "2b64e2f0193851d4135a2e885cd08a65"
     },
     "api": {
-        "request_host": "test.com",
-        "upstream_url": "http://mockbin.org/",
-        "created_at": 1432855823000,
-        "name": "test.com",
-        "id": "fbaf95a1-cd04-4bf6-cb73-6cb3285fef58"
+        "created_at": 1488830759000,
+        "hosts": [
+          "example.org"
+        ],
+        "http_if_terminated": true,
+        "https_only": false,
+        "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+        "name": "example-api",
+        "preserve_host": false,
+        "retries": 5,
+        "strip_uri": true,
+        "upstream_connect_timeout": 60000,
+        "upstream_read_timeout": 60000,
+        "upstream_send_timeout": 60000,
+        "upstream_url": "http://httpbin.org"
     },
     "latencies": {
         "proxy": 1430,

--- a/app/plugins/loggly.md
+++ b/app/plugins/loggly.md
@@ -87,16 +87,24 @@ Every request will be transmitted to Loggly in [SYSLOG](https://en.wikipedia.org
     },
     "authenticated_entity": {
         "consumer_id": "80f74eef-31b8-45d5-c525-ae532297ea8e",
-        "created_at":	1437643103000,
         "id": "eaa330c0-4cff-47f5-c79e-b2e4f355207e",
-        "key": "2b64e2f0193851d4135a2e885cd08a65"
     },
     "api": {
-        "request_host": "test.com",
-        "upstream_url": "http://httpbin.org/",
-        "created_at": 1432855823000,
-        "name": "test.com",
-        "id": "fbaf95a1-cd04-4bf6-cb73-6cb3285fef58"
+        "created_at": 1488830759000,
+        "hosts": [
+          "example.org"
+        ],
+        "http_if_terminated": true,
+        "https_only": false,
+        "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+        "name": "example-api",
+        "preserve_host": false,
+        "retries": 5,
+        "strip_uri": true,
+        "upstream_connect_timeout": 60000,
+        "upstream_read_timeout": 60000,
+        "upstream_send_timeout": 60000,
+        "upstream_url": "http://httpbin.org"
     },
     "latencies": {
         "proxy": 1430,

--- a/app/plugins/syslog.md
+++ b/app/plugins/syslog.md
@@ -82,16 +82,24 @@ Every request will be logged to System log in [SYSLOG](https://en.wikipedia.org/
     },
     "authenticated_entity": {
         "consumer_id": "80f74eef-31b8-45d5-c525-ae532297ea8e",
-        "created_at":	1437643103000,
         "id": "eaa330c0-4cff-47f5-c79e-b2e4f355207e",
-        "key": "2b64e2f0193851d4135a2e885cd08a65"
     },
     "api": {
-        "request_host": "test.com",
-        "upstream_url": "http://httpbin.org/",
-        "created_at": 1432855823000,
-        "name": "test.com",
-        "id": "fbaf95a1-cd04-4bf6-cb73-6cb3285fef58"
+        "created_at": 1488830759000,
+        "hosts": [
+          "example.org"
+        ],
+        "http_if_terminated": true,
+        "https_only": false,
+        "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+        "name": "example-api",
+        "preserve_host": false,
+        "retries": 5,
+        "strip_uri": true,
+        "upstream_connect_timeout": 60000,
+        "upstream_read_timeout": 60000,
+        "upstream_send_timeout": 60000,
+        "upstream_url": "http://httpbin.org"
     },
     "latencies": {
         "proxy": 1430,

--- a/app/plugins/tcp-log.md
+++ b/app/plugins/tcp-log.md
@@ -54,7 +54,7 @@ form parameter                          | default | description
 
 ## Log Format
 
-Every request will be logged separately in a JSON object separated by a new line `\n`, with the following format:
+Every request will be logged separately in a JSON object, separated by a new line `\n`, with the following format:
 
 ```json
 {
@@ -85,16 +85,29 @@ Every request will be logged separately in a JSON object separated by a new line
     },
     "authenticated_entity": {
         "consumer_id": "80f74eef-31b8-45d5-c525-ae532297ea8e",
-        "created_at":	1437643103000,
         "id": "eaa330c0-4cff-47f5-c79e-b2e4f355207e",
-        "key": "2b64e2f0193851d4135a2e885cd08a65"
     },
     "api": {
-        "request_host": "test.com",
-        "upstream_url": "http://mockbin.org/",
-        "created_at": 1432855823000,
-        "name": "test.com",
-        "id": "fbaf95a1-cd04-4bf6-cb73-6cb3285fef58"
+        "created_at": 1488830759000,
+        "hosts": [
+          "example.org"
+        ],
+        "http_if_terminated": true,
+        "https_only": false,
+        "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+        "name": "example-api",
+        "preserve_host": false,
+        "retries": 5,
+        "strip_uri": true,
+        "upstream_connect_timeout": 60000,
+        "upstream_read_timeout": 60000,
+        "upstream_send_timeout": 60000,
+        "upstream_url": "http://httpbin.org"
+    },
+    "latencies": {
+        "proxy": 1430,
+        "kong": 9,
+        "request": 1921
     },
     "started_at": 1433209822425,
     "client_ip": "127.0.0.1"

--- a/app/plugins/udp-log.md
+++ b/app/plugins/udp-log.md
@@ -52,7 +52,7 @@ parameter                      | default | description
 
 ## Log Format
 
-Every request will be logged separately in a JSON object, with the following format:
+Every request will be logged separately in a JSON object with the following format:
 
 ```json
 {
@@ -83,16 +83,24 @@ Every request will be logged separately in a JSON object, with the following for
     },
     "authenticated_entity": {
         "consumer_id": "80f74eef-31b8-45d5-c525-ae532297ea8e",
-        "created_at":	1437643103000,
         "id": "eaa330c0-4cff-47f5-c79e-b2e4f355207e",
-        "key": "2b64e2f0193851d4135a2e885cd08a65"
     },
     "api": {
-        "request_host": "test.com",
-        "upstream_url": "http://httpbin.org/",
-        "created_at": 1432855823000,
-        "name": "test.com",
-        "id": "fbaf95a1-cd04-4bf6-cb73-6cb3285fef58"
+        "created_at": 1488830759000,
+        "hosts": [
+          "example.org"
+        ],
+        "http_if_terminated": true,
+        "https_only": false,
+        "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+        "name": "example-api",
+        "preserve_host": false,
+        "retries": 5,
+        "strip_uri": true,
+        "upstream_connect_timeout": 60000,
+        "upstream_read_timeout": 60000,
+        "upstream_send_timeout": 60000,
+        "upstream_url": "http://httpbin.org"
     },
     "latencies": {
         "proxy": 1430,


### PR DESCRIPTION
* Missing latency field in TCP logging example
* Proper upstream_url in several logging examples
* Remove undefined authenticated_entity keys