### PR TITLE
change hosts response value

### DIFF
--- a/app/docs/0.10.x/getting-started/adding-your-api.md
+++ b/app/docs/0.10.x/getting-started/adding-your-api.md
@@ -45,7 +45,7 @@ configuration of your Kong instance or cluster.
     {
       "created_at": 1488830759000,
       "hosts": [
-          "example.org"
+          "example.com"
       ],
       "http_if_terminated": true,
       "https_only": false,


### PR DESCRIPTION
The response value for hosts attribute in the Add Your API section had
an incorrect value of example.org. It is now changed to example.com to
reflect the rest of the document.