### PR TITLE
fix(optimisations): load fonts asynchronously

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -52,6 +52,22 @@
   ##preload_assets##
 
   <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico"/>
-  <link rel="stylesheet" href="//cloud.typography.com/7506032/804186/css/fonts.css"/>
   <link rel="stylesheet" href="/assets/styles.css?v={{ site.time | date: '%s' }}"/>
+
+  <!-- Web Fonts -->
+  <script>
+   WebFontConfig = {
+      custom: {
+        families: ['Whitney A', 'Whitney B', 'Whitney SSm A', 'Whitney SSm B', 'Whitney SSm Smallcaps A', 'Whitney SSm Smallcaps B'],
+        urls: ['//cloud.typography.com/7506032/804186/css/fonts.css']
+      }
+   };
+
+   (function(d) {
+      var wf = d.createElement('script'), s = d.scripts[0];
+      wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+      wf.async = true;
+      s.parentNode.insertBefore(wf, s);
+   })(document);
+  </script>
 </head>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,7 +156,7 @@ gulp.task('html', ['jekyll'], function () {
     }))
     .pipe(gulp.dest(paths.dist))
     .pipe($.size())
-    .pipe(browserSync.stream())
+    .pipe(browserSync.stream({ once: true }))
 })
 
 gulp.task('docs', function (cb) {


### PR DESCRIPTION
Upon further investigation after #353, I felt more could be done for folks loading getkong for the first time.

- greatly reduce load times with async font loading
- unfortunately causes FOUT (flash of unstyled text)
