### PR TITLE
feat(proxy) add trusted_ips for forwarded headers documentation

### DIFF
--- a/app/docs/0.10.x/configuration.md
+++ b/app/docs/0.10.x/configuration.md
@@ -423,8 +423,6 @@ Default: `60`
 
 ---
 
----
-
 ##### **real_ip_header**
 
 Defines the request header field whose value will be used to replace the client
@@ -432,21 +430,23 @@ address.
 
 See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
 
-Default: X-Real-IP
+Default: `X-Real-IP`
 
 ---
 
 ##### **real_ip_recursive**
 
-If recursive search is disabled, the original client address that matches one of
-the trusted addresses is replaced by the last address sent in the request header
-field defined by the real_ip_header directive. If recursive search is enabled,
-the original client address that matches one of the trusted addresses is replaced
-by the last non-trusted address sent in the request header field.
+If recursive search is **disabled**:
+
+* The original client request that matches one of the trusted addresses is replaced by the last address sent in the request header field defined by `real_ip_header`.
+
+If recursive search is **enabled**:
+
+* The original client request that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field defined by `real_ip_header`.
 
 See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
 
-Default: off
+Default: `off`
 
 ---
 
@@ -454,7 +454,7 @@ Default: off
 
 Defines trusted addresses that are known to send correct replacement addresses.
 This is used by [ngx_http_realip_module][ngx-http-realip-module]
-(`set_real_ip_from` directive`) and for setting `X-Forwarded-*` headers.
+(`set_real_ip_from` directive) and for setting `X-Forwarded-*` headers.
 
 See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
 
@@ -739,3 +739,4 @@ Default: `30`
 
 [Penlight]: http://stevedonovan.github.io/Penlight/api/index.html
 [pl.template]: http://stevedonovan.github.io/Penlight/api/libraries/pl.template.html
+[ngx-http-realip-module]: http://nginx.org/en/docs/http/ngx_http_realip_module.html

--- a/app/docs/0.10.x/configuration.md
+++ b/app/docs/0.10.x/configuration.md
@@ -421,6 +421,45 @@ exceeded, the least recently used connections are closed.
 
 Default: `60`
 
+---
+
+---
+
+##### **real_ip_header**
+
+Defines the request header field whose value will be used to replace the client
+address.
+
+See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+
+Default: X-Real-IP
+
+---
+
+##### **real_ip_recursive**
+
+If recursive search is disabled, the original client address that matches one of
+the trusted addresses is replaced by the last address sent in the request header
+field defined by the real_ip_header directive. If recursive search is enabled,
+the original client address that matches one of the trusted addresses is replaced
+by the last non-trusted address sent in the request header field.
+
+See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
+
+Default: off
+
+---
+
+##### **trusted_ips**
+
+Defines trusted addresses that are known to send correct replacement addresses.
+This is used by [ngx_http_realip_module][ngx-http-realip-module]
+(`set_real_ip_from` directive`) and for setting `X-Forwarded-*` headers.
+
+See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
+
+Default: none
+
 [Back to TOC](#table-of-contents)
 
 ---

--- a/app/docs/0.10.x/configuration.md
+++ b/app/docs/0.10.x/configuration.md
@@ -426,11 +426,15 @@ Default: `60`
 ##### **real_ip_header**
 
 Defines the request header field whose value will be used to replace the client
-address.
+address. The special value of `proxy_protocol` will not only set the real IP from
+the proxy protocol header but it will also switch the Kong proxy to the proxy
+protocol mode using Nginx `listen` directive.
 
 See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
 
 Default: `X-Real-IP`
+
+Example: `X-Forwarded-For`
 
 ---
 
@@ -438,11 +442,15 @@ Default: `X-Real-IP`
 
 If recursive search is **disabled**:
 
-* The original client request that matches one of the trusted addresses is replaced by the last address sent in the request header field defined by `real_ip_header`.
+* The original client request that matches one of the trusted addresses is
+  replaced by the last address sent in the request header field defined by
+  `real_ip_header`.
 
 If recursive search is **enabled**:
 
-* The original client request that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field defined by `real_ip_header`.
+* The original client request that matches one of the trusted addresses is
+  replaced by the last non-trusted address sent in the request header field
+  defined by `real_ip_header`.
 
 See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
 
@@ -455,6 +463,10 @@ Default: `off`
 Defines trusted addresses that are known to send correct replacement addresses.
 This is used by [ngx_http_realip_module][ngx-http-realip-module]
 (`set_real_ip_from` directive) and for setting `X-Forwarded-*` headers.
+
+Opposite to the default trust `none` is to configure trust `all` by setting the
+value to `0.0.0.0/0, ::/0`. It is always a good idea to keep defaults or list
+the specific trusted proxies here so that the remote IP cannot be spoofed.
 
 See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
 

--- a/app/docs/0.10.x/proxy.md
+++ b/app/docs/0.10.x/proxy.md
@@ -578,11 +578,30 @@ Kong will send the request over HTTP/1.1, and set the following headers:
 
 - `Host: <your_upstream_host>`, as previously described in this document.
 - `Connection: keep-alive`, to allow for reusing the upstream connections
-- `X-Real-IP: <$proxy_add_x_forwarded_for>`, where `$proxy_add_x_forwarded_for`
-  is the variable bearing the same name provided by
-  [ngx_http_proxy_module][ngx-http-proxy-module].
+- `X-Real-IP: <$remote_addr>`, where `$remote_addr` is the variable bearing
+  the same name provided by
+  [ngx_http_core_module][ngx-remote-addr-variable]. Please note that the
+  `$remote_addr` is likely overwritten by
+  [ngx_http_realip_module][ngx-http-realip-module].
+- `X-Forwarded-For: <address>`, where `<address>` is the the content of
+  `$realip_remote_addr` provided by the
+  [ngx_http_realip_module][ngx-http-realip-module] appended to the request
+  header with the same name.
 - `X-Forwarded-Proto: <protocol>`, where `<protocol>` is the protocol used by
-  the client.
+  the client. In the case where `$realip_remote_addr` is one of the **trusted**
+  addresses, the request header with the same name gets forwarded if provided.
+  Otherwise the value of `$scheme` variable provided by the
+  [ngx_http_core_module][ngx-scheme-variable] will be used.
+- `X-Forwarded-Host: <host>`, where `<host>` is the host name send by
+  the client. In the case where `$realip_remote_addr` is one of the **trusted**
+  addresses, the request header with the same name gets forwarded if provided.
+  Otherwise the value of `$host` variable provided by the
+  [ngx_http_core_module][ngx-host-variable] will be used.
+- `X-Forwarded-Port: <port>`, where `<port>` is the port of the server which
+  accepted a request. In the case where `$realip_remote_addr` is one of the
+  **trusted** addresses, the request header with the same name gets forwarded
+  if provided. Otherwise the value of `$server_port` variable provided by the
+  [ngx_http_core_module][ngx-server-port-variable] will be used.
 
 All the other request headers are forwarded as-is by Kong.
 
@@ -820,4 +839,9 @@ topic we just covered.
 [API]: /docs/{{page.kong_version}}/admin-api
 
 [ngx-http-proxy-module]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html
+[ngx-http-realip-module]: http://nginx.org/en/docs/http/ngx_http_realip_module.html
+[ngx-remote-addr-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_remote_addr
+[ngx-scheme-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_scheme
+[ngx-host-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host
+[ngx-server-port-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_server_port
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication

--- a/app/docs/0.10.x/proxy.md
+++ b/app/docs/0.10.x/proxy.md
@@ -581,7 +581,7 @@ Kong will send the request over HTTP/1.1, and set the following headers:
 - `X-Real-IP: <$remote_addr>`, where `$remote_addr` is the variable bearing
   the same name provided by
   [ngx_http_core_module][ngx-remote-addr-variable]. Please note that the
-  `$remote_addr` is likely overwritten by
+  `$remote_addr` is likely overridden by
   [ngx_http_realip_module][ngx-http-realip-module].
 - `X-Forwarded-For: <address>`, where `<address>` is the the content of
   `$realip_remote_addr` provided by the
@@ -590,17 +590,17 @@ Kong will send the request over HTTP/1.1, and set the following headers:
 - `X-Forwarded-Proto: <protocol>`, where `<protocol>` is the protocol used by
   the client. In the case where `$realip_remote_addr` is one of the **trusted**
   addresses, the request header with the same name gets forwarded if provided.
-  Otherwise the value of `$scheme` variable provided by the
+  Otherwise, the value of `$scheme` variable provided by the
   [ngx_http_core_module][ngx-scheme-variable] will be used.
-- `X-Forwarded-Host: <host>`, where `<host>` is the host name send by
+- `X-Forwarded-Host: <host>`, where `<host>` is the host name sent by
   the client. In the case where `$realip_remote_addr` is one of the **trusted**
   addresses, the request header with the same name gets forwarded if provided.
-  Otherwise the value of `$host` variable provided by the
+  Otherwise, the value of `$host` variable provided by the
   [ngx_http_core_module][ngx-host-variable] will be used.
 - `X-Forwarded-Port: <port>`, where `<port>` is the port of the server which
   accepted a request. In the case where `$realip_remote_addr` is one of the
   **trusted** addresses, the request header with the same name gets forwarded
-  if provided. Otherwise the value of `$server_port` variable provided by the
+  if provided. Otherwise, the value of `$server_port` variable provided by the
   [ngx_http_core_module][ngx-server-port-variable] will be used.
 
 All the other request headers are forwarded as-is by Kong.


### PR DESCRIPTION
Proxy Reference:

* X-Real-IP header
* X-Forwarded-For header
* X-Forwarded-Proto header
* X-Forwarded-Host header
* X-Forwarded-Port header

Configuration Reference:

* real_ip_header property
* real_ip_recursive property
* trusted_ips property