### PR TITLE
Noted the name change on config.origin

### DIFF
--- a/app/plugins/cors.md
+++ b/app/plugins/cors.md
@@ -45,7 +45,7 @@ more information.
 form parameter                             | default | description
 ---:                                       | ---     | ---
 `name`                                     |         | Name of the plugin to use, in this case: `cors`
-`config.origins`<br>*optional*             |         | A comma-separated list of allows domains for the `Access-Control-Allow-Origin` header. If you wish to allow all origins, add `*` as a single value to this configuration field.
+`config.origins`<br>Formerly `config.origin`<br>*optional*             |         | A comma-separated list of allows domains for the `Access-Control-Allow-Origin` header. If you wish to allow all origins, add `*` as a single value to this configuration field.
 `config.methods`<br>*optional*             | `GET,HEAD,PUT,PATCH,POST,DELETE` | Value for the `Access-Control-Allow-Methods` header, expects a comma delimited string (e.g. `GET,POST`).
 `config.headers`<br>*optional*             | Value of the `Access-Control-Request-Headers`<br>request header | Value for the `Access-Control-Allow-Headers` header, expects a comma delimited string (e.g. `Origin, Authorization`).
 `config.exposed_headers`<br>*optional*     |         | Value for the `Access-Control-Expose-Headers` header, expects a comma delimited string (e.g. `Origin, Authorization`). If not specified, no custom headers are exposed.


### PR DESCRIPTION
This was formerly config.origin and was updated to config.origins so I wanted to point that out