### PR TITLE
added tag to the kong docker command

### DIFF
--- a/app/install/docker.md
+++ b/app/install/docker.md
@@ -46,7 +46,7 @@ Here is a quick example showing how to link a Kong container to a Cassandra or P
                   -p 8001:8001 \
                   -p 7946:7946 \
                   -p 7946:7946/udp \
-                  kong
+                  kong:latest
     ```
 
 3. **Kong is running:**


### PR DESCRIPTION
I think it is best practice to use a tag when calling an image. Using latest will save us the step of adding in the number each time. This may also avoid confusion for people who already have an older image of Kong cached.