### PR TITLE
Fix/plugins

### DIFF
--- a/app/_assets/stylesheets/pages/plugins.less
+++ b/app/_assets/stylesheets/pages/plugins.less
@@ -32,6 +32,10 @@
   }
 
   .plugins-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
     + .page-plugins-title {
       margin-top: 15px;
     }
@@ -43,11 +47,18 @@
 
   .plugin-plate {
     &:extend(.columns all, .four.columns);
+    display: flex;
+    flex: 0 1 100%;
+    flex-direction: column;
     margin-bottom: 40px;
     border: 1px solid #e0e0e0;
     border-radius: 5px;
     position: relative;
     transition: border-color .2s;
+
+    @media (min-width: @grid-width-sm) {
+      flex-basis: 30.65%;
+    }
 
     &:hover {
       border-color: #80caff;

--- a/app/_layouts/plugin.html
+++ b/app/_layouts/plugin.html
@@ -4,8 +4,7 @@ sitemap: true
 id: page-plugin
 header_btn_text: Report Bug
 header_btn_href: mailto:support@mashape.com?subject={{ page.header_title }} Plugin Bug
-breadcrumbs:
-  Plugins: /plugins
+breadcrumbs: null
 ---
 
 <div class="page {{ page.id }}">

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -60,8 +60,7 @@ defaults:
     values:
       layout: 'about'
       header_html: '<a class="github-button" href="https://github.com/Mashape/kong" data-style="mega" data-count-href="/Mashape/kong/stargazers" data-count-api="/repos/Mashape/kong#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star Mashape/kong on GitHub">Star</a>&nbsp;<a class="github-button" href="https://github.com/Mashape/kong/fork" data-icon="octicon-repo-forked" data-style="mega" data-count-href="/Mashape/kong/network" data-count-api="/repos/Mashape/kong#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork Mashape/kong on GitHub">Fork</a>'
-      breadcrumbs:
-        About: /about
+      breadcrumbs: null
 
   - scope:
       path: 'plugins'
@@ -71,8 +70,7 @@ defaults:
       header_btn_href: https://github.com/Mashape/kong/issues/new
       header_btn_target: _blank
       id: page-plugin
-      breadcrumbs:
-        Plugins: /plugins
+      breadcrumbs: null
       nav:
         - label: Getting Started
           items:


### PR DESCRIPTION
This fix cleans up the plugins page such that the cards have a more uniform layout (thanks, Flexbox).

- give plugins page cards a uniform layout
- bonus: remove breadcrumb navigation from about and plugins pages

## Before
![image](https://cloud.githubusercontent.com/assets/12798751/24767196/318b7c56-1acc-11e7-923f-dbd476bd4d7e.png)

## After
![image](https://cloud.githubusercontent.com/assets/12798751/24767201/3c434e80-1acc-11e7-8d87-90e7aee8d3ec.png)

## Breadcrumb Removed
![image](https://cloud.githubusercontent.com/assets/12798751/24767247/5d8f83c4-1acc-11e7-905e-9d3a16b64f52.png)
