### PR TITLE
docs(jwt) Denote necessary Content-Type header for credential creation

### DIFF
--- a/app/plugins/jwt.md
+++ b/app/plugins/jwt.md
@@ -88,7 +88,7 @@ A [Consumer][consumer-object] can have many JWT credentials.
 You can provision a new HS256 JWT credential by issuing the following HTTP request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/jwt
+$ curl -X POST http://kong:8001/consumers/{consumer}/jwt -H "Content-Type: application/x-www-form-urlencoded"
 HTTP/1.1 201 Created
 
 {


### PR DESCRIPTION
All credential options have default creation values, so there's no
need for the user to define any request body params. However, curl
will not automatically send the Content-Type header as a result of
definine the method as POST via -X; this results in an unsupported
media type error generated from the Admin API.