### PR TITLE
feat(includes): add support link to nav and footer

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -19,6 +19,7 @@
             <li><a href="http://blog.mashape.com/">Blog</a></li>
             <li><a href="https://www.mashape.com/jobs/">Jobs</a></li>
             <li><a href="https://www.mashape.com/contact/">Contact</a></li>
+            <li><a href="https://support.mashape.com/">Support</a></li>
           </ul>
         </nav>
       </li>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -9,6 +9,7 @@
       </nav>
       <nav class="enterprise-contact one-half column">
         <ul>
+          <li><a href="https://support.mashape.com/">Support</a></li>
           <li><a href="https://www.mashape.com/enterprise/#demo-form">Request Demo</a></li>
         </ul>
       </nav>
@@ -29,6 +30,7 @@
           <li><a href="/community/" {% if page.url == "/community/" %} class="active"{% endif %}>Community</a></li>
           <li><a href="https://www.mashape.com/enterprise/">Enterprise</a></li>
           <li><a href="{{ site.repos.kong }}" target="_blank">GitHub</a></li>
+          <li><a href="https://support.mashape.com/">Support</a></li>
           <li>
             <a href="/install/" class="button button-dark{% if page.url == "/install/" %} active{% endif %}" data-analytics='{"event": "Clicked download", "type": "button", "location": "header"}'>Installation</a>
           </li>


### PR DESCRIPTION
Customer support would like to make user access to the support portal easier by adding links to every marketing site's header and footer.

## Header

![image](https://cloud.githubusercontent.com/assets/12798751/25391972/72bef4fe-29a5-11e7-8e80-902013dc0269.png)

## Mobile Header

![image](https://cloud.githubusercontent.com/assets/12798751/25391993/7db0e43a-29a5-11e7-9c15-e7aa06786e36.png)

## Footer

![image](https://cloud.githubusercontent.com/assets/12798751/25392001/84471e54-29a5-11e7-84d1-d24e397256c8.png)
