### PR TITLE
fix(nav): hide support in second header row

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -247,3 +247,10 @@ nav {
     }
   }
 }
+
+// In lieu of bootstrap
+@media (min-width: 1101px) {
+  .hidden-lg {
+    display: none !important;
+  }
+}

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -30,7 +30,7 @@
           <li><a href="/community/" {% if page.url == "/community/" %} class="active"{% endif %}>Community</a></li>
           <li><a href="https://www.mashape.com/enterprise/">Enterprise</a></li>
           <li><a href="{{ site.repos.kong }}" target="_blank">GitHub</a></li>
-          <li><a href="https://support.mashape.com/">Support</a></li>
+          <li class="hidden-lg"><a href="https://support.mashape.com/">Support</a></li>
           <li>
             <a href="/install/" class="button button-dark{% if page.url == "/install/" %} active{% endif %}" data-analytics='{"event": "Clicked download", "type": "button", "location": "header"}'>Installation</a>
           </li>


### PR DESCRIPTION
- hide support link in second header row since it was causing display issues, taking up too much width
- still show support link on small screens

## Before

![image](https://cloud.githubusercontent.com/assets/12798751/25407099/171d2940-29d7-11e7-88a6-b8c24b41669a.png)

## After

![image](https://cloud.githubusercontent.com/assets/12798751/25407111/1de74b8e-29d7-11e7-9e36-f05843abe6fc.png)
