### PR TITLE
Broken self link, and misc markdown fixes

### DIFF
--- a/app/docs/0.10.x/auth.md
+++ b/app/docs/0.10.x/auth.md
@@ -200,12 +200,11 @@ the consumer, or the last plugin that will set its configured anonymous consumer
 tokens etc. will require authentication by the other configured auth plugins.
 
 <div class="alert alert-warning">
-  When multiple authentication plugins are enabled in an `OR` fashion on a given API, and it is desired that 
-  anonymous access be forbidden, then the [`request-termination` plugin][request-termination] should be
+  When multiple authentication plugins are enabled in an <tt>OR</tt> fashion on a given API, and it is desired that 
+  anonymous access be forbidden, then the <a href="/plugins/request-termination"><tt>request-termination</tt> plugin</a> should be
   configured on the anonymous consumer. Failure to do so will allow unauthorized requests.
 </div>
 
 
 [plugins]: https://getkong.org/plugins/
 [key-auth]: /plugins/key-authentication
-[request-termination]: /plugins/request-termination

--- a/app/docs/0.10.x/proxy.md
+++ b/app/docs/0.10.x/proxy.md
@@ -806,14 +806,14 @@ This website is Open-Source and can be found at
 Feel free to provide feedback to this document there, or propose improvements!
 
 If not already done, we suggest that you also read the
-[Load balancing Reference][load-balancing-guide], as it closely relates to the
+[Load balancing Reference][load-balancing-reference], as it closely relates to the
 topic we just covered.
 
 [Back to TOC](#table-of-contents)
 
 [plugin-configuration-object]: /docs/{{page.kong_version}}/admin-api#plugin-configuration-object
 [plugin-development-guide]: /docs/{{page.kong_version}}/admin-api#plugin-development-guide
-[load-balancing-reference]: /docs/{{page.kong_version}}/admin-api#load-balancing-guide
+[load-balancing-reference]: /docs/{{page.kong_version}}/loadbalancing
 [configuration-reference]: /docs/{{page.kong_version}}/configuration-reference
 [adding-your-api]: /docs/{{page.kong_version}}/getting-started/adding-your-api
 [API]: /docs/{{page.kong_version}}/admin-api

--- a/app/docs/0.10.x/proxy.md
+++ b/app/docs/0.10.x/proxy.md
@@ -802,7 +802,7 @@ mechanism of Kong, from how is a request matched to an API, to how to allow for
 using the WebSocket protocol or setup SSL for an API.
 
 This website is Open-Source and can be found at
-[github.com/Mashape/getkong.org][https://github.com/Mashape/getkong.org/].
+[github.com/Mashape/getkong.org](https://github.com/Mashape/getkong.org/).
 Feel free to provide feedback to this document there, or propose improvements!
 
 If not already done, we suggest that you also read the

--- a/app/docs/0.10.x/proxy.md
+++ b/app/docs/0.10.x/proxy.md
@@ -811,8 +811,8 @@ topic we just covered.
 
 [Back to TOC](#table-of-contents)
 
-[plugin-configuration-object]: /docs/{{page.kong_version}}/admin-api#plugin-configuration-object
-[plugin-development-guide]: /docs/{{page.kong_version}}/admin-api#plugin-development-guide
+[plugin-configuration-object]: /docs/{{page.kong_version}}/admin-api#plugin-object
+[plugin-development-guide]: /docs/{{page.kong_version}}/plugin-development
 [load-balancing-reference]: /docs/{{page.kong_version}}/loadbalancing
 [configuration-reference]: /docs/{{page.kong_version}}/configuration-reference
 [adding-your-api]: /docs/{{page.kong_version}}/getting-started/adding-your-api

--- a/app/plugins/http-log.md
+++ b/app/plugins/http-log.md
@@ -156,4 +156,6 @@ A few considerations on the above JSON object:
 This logging plugin will only log HTTP request and response data. If you are
 looking for the Kong process error file (which is the nginx error file), then
 you can find it at the following path: 
-`{[prefix](/docs/{{site.data.kong_latest.release}}/configuration/#prefix)}/logs/error.log`.
+`$KONG_PREFIX/logs/error.log`,
+where `$KONG_PREFIX` means
+[prefix in the configuration](/docs/{{site.data.kong_latest.release}}/configuration/#prefix).


### PR DESCRIPTION
This journey started when I noticed that (ironically) the [this website is Open-Source](https://getkong.org/docs/0.10.x/proxy/#conclusion) link is incorrectly marked-down(?). Then I noticed the markdown link right below it was also bogus, which led me to look for other incorrect markdown `grep -Ero '\[[a-z0-9-]{5,}\]' .` ... and here we are.

I tested them locally, and everything looked like I expected, so I hope it works when deployed, also.