### PR TITLE
api plugin update and delete docs should match Kong routes

### DIFF
--- a/app/docs/0.10.x/admin-api.md
+++ b/app/docs/0.10.x/admin-api.md
@@ -938,12 +938,12 @@ HTTP 200 OK
 
 #### Endpoint
 
-<div class="endpoint patch">/apis/{api name or id}/plugins/{plugin name or id}</div>
+<div class="endpoint patch">/apis/{api name or id}/plugins/{plugin id}</div>
 
 Attributes | Description
 ---:| ---
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to update the plugin configuration
-`plugin name or id`<br>**required** | The unique identifier **or** the name of the plugin configuration to update on this API
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to update on this API
 
 #### Request Body
 
@@ -1002,12 +1002,12 @@ See POST and PATCH responses.
 
 #### Endpoint
 
-<div class="endpoint delete">/apis/{api name or id}/plugins/{plugin name or id}</div>
+<div class="endpoint delete">/apis/{api name or id}/plugins/{plugin id}</div>
 
 Attributes | Description
 ---:| ---
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to delete the plugin configuration
-`plugin name or id`<br>**required** | The unique identifier **or** the name of the plugin configuration to delete on this API
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to delete on this API
 
 #### Response
 


### PR DESCRIPTION
Currently (0.10.2) Kong does not support UPDATE or DELETE by name. 

See also: https://github.com/Mashape/kong/issues/2527 - if this gets fixed this PR won't be necessary.