### PR TITLE
feat(styles): remove bottom margin removal from leading paragraph

### DIFF
--- a/app/_assets/stylesheets/pages/plugin.less
+++ b/app/_assets/stylesheets/pages/plugin.less
@@ -25,10 +25,6 @@
       }
     }
 
-    > p:first-child {
-      margin-bottom: -20px;
-    }
-
     h2 {
       font-size: 26px;
       margin: 20px 0;


### PR DESCRIPTION
Fixes the leading paragraph for the Plugins page by removing the margin removal declaration.

<img width="1119" alt="screen shot 2017-05-24 at 3 10 19 pm" src="https://cloud.githubusercontent.com/assets/198276/26427786/24596a74-4093-11e7-9999-a83c72ffe99a.png">
