### PR TITLE
fix(plugins): change flexbox widths for IE11

### DIFF
--- a/app/_assets/stylesheets/pages/plugins.less
+++ b/app/_assets/stylesheets/pages/plugins.less
@@ -44,7 +44,7 @@
   .plugin-plate {
     &:extend(.columns all, .four.columns);
     display: flex;
-    flex: 0 1 100%;
+    flex: 1 1 100%;
     flex-direction: column;
     margin-bottom: 40px;
     border: 1px solid #e0e0e0;
@@ -53,7 +53,8 @@
     transition: border-color .2s;
 
     @media (min-width: @grid-width-sm) {
-      flex-basis: 30.65%;
+      flex-basis: 30%;
+      max-width: 30.65%;
     }
 
     &:hover {


### PR DESCRIPTION
- Fix flexbox widths on Plugins page for IE11 users.

## Before

![image](https://cloud.githubusercontent.com/assets/12798751/26452574/69c2e6ee-412e-11e7-8ece-26572cf9fad6.png)

## After

![image](https://cloud.githubusercontent.com/assets/12798751/26452591/7dc951f0-412e-11e7-8818-3be72068a920.png)
