### PR TITLE
docs(aws-lambda) document the new unhanded_status config option

### DIFF
--- a/app/plugins/aws-lambda.md
+++ b/app/plugins/aws-lambda.md
@@ -49,6 +49,7 @@ form parameter                             | default | description
 `config.log_type`<br>*optional*            | `Tail`  | The [`LogType`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function. By default `None` and `Tail` are supported
 `config.timeout`<br>*optional*          | `60000` | An optional timeout in milliseconds when invoking the function
 `config.keepalive`<br>*optional*        | `60000` | An optional value in milliseconds that defines for how long an idle connection will live before being closed
+`config.unhandled_status`               | ``      | The response status code to use (instead of the default `200`, `202`, or `204`) in the case of an [`Unhandled` Function Error](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_ResponseSyntax). |
 ----
 
 ### Sending parameters


### PR DESCRIPTION
Pre-emptive PR for when https://github.com/Mashape/kong/pull/2587 gets released.

<img width="793" alt="screen shot 2017-06-03 at 12 58 16" src="https://cloud.githubusercontent.com/assets/1694055/26753354/6063fa90-485c-11e7-8c4d-8efece34d02e.png">
