### PR TITLE
fix(travis): upgrade node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4"
+  - "7"
 
 sudo: false
 notifications:


### PR DESCRIPTION
Node 4 was giving our builds issues when Yarn ran. Now it ought to work.