### PR TITLE
docs(configuration) serving website and API

### DIFF
--- a/app/docs/0.10.x/configuration.md
+++ b/app/docs/0.10.x/configuration.md
@@ -12,6 +12,7 @@ title: Configuration Reference
 - [Custom Nginx configuration & embedding Kong](#custom-nginx-configuration-embedding-kong)
   - [Custom Nginx configuration](#custom-nginx-configuration)
   - [Embedding Kong](#embedding-kong)
+  - [Serving both a website and your APIs from Kong](#serving-both-a-website-and-your-apis-from-kong)
 - [Properties reference](#properties-reference)
   - [General section](#general-section)
   - [Nginx section](#nginx-section)
@@ -200,6 +201,68 @@ http {
   access_log logs/access.log;
 
   ... # etc
+}
+```
+
+#### Serving both a website and your APIs from Kong
+
+A common use case for API providers is to make Kong serve both a website
+and the APIs themselves over the Proxy port &mdash; `80` or `443` in
+production. For example, `https://my-api.com` (Website) and
+`https://my-api.com/api/v1` (API).
+
+To achieve this, we cannot simply declare a new virtual server block,
+like we did in the previous section. A good solution is to use a custom
+Nginx configuration template which inlines `nginx_kong.lua` and adds a new
+`location` block serving the website alongside the Kong Proxy `location`
+block:
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{ "{{NGINX_WORKER_PROCESSES" }}}}; # can be set by kong.conf
+daemon ${{ "{{NGINX_DAEMON" }}}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log logs/error.log ${{ "{{LOG_LEVEL" }}}}; # can be set by kong.conf
+events {}
+
+http {
+  # here, we inline the contents of nginx_kong.lua
+  charset UTF-8;
+
+  # any contents until Kong's Proxy server block
+  ...
+
+  # Kong's Proxy server block
+  server {
+    server_name kong;
+
+    # any contents until the location / block
+    ...
+
+    # here, we declare our custom location serving our website
+    # (or API portal) which we can optimize for serving static assets
+    location / {
+      root /var/www/my-api.com;
+      index index.htm index.html;
+      ...
+    }
+
+    # Kong's Proxy location / has been changed to /api/v1
+    location /api/v1 {
+      set $upstream_host nil;
+      set $upstream_scheme nil;
+      set $upstream_uri nil;
+
+      # Any remaining configuration for the Proxy location
+      ...
+    }
+  }
+
+  # Kong's Admin server block goes below
 }
 ```
 


### PR DESCRIPTION
Instructions on how to setup a website with the same server
name and port as the API.