### PR TITLE
docs(install) update OpenResty version and flags

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -99,6 +99,6 @@
     luarocks: "2.4.2"
     cassandra: "3.x.x"
     postgres: "9.4+"
-    openresty: "1.11.2.2"
+    openresty: "1.11.2.4"
     serf: "0.7.0"
   lua_doc: true

--- a/app/install/source.md
+++ b/app/install/source.md
@@ -28,8 +28,7 @@ redirect_from: /install/compile/
       --with-http_realip_module \
       --with-http_ssl_module \
       --with-http_stub_status_module \
-      --with-http_v2_module \
-      --without-luajit-lua52
+      --with-http_v2_module
     ```
 
     You might have to specify `--with-openssl` and you can add any other option


### PR DESCRIPTION
* Bump OpenResty version to the latest release
* Remove --without-luajit-lua52, matching setup
  currently used in Travis.