### PR TITLE
docs(configuration) update to use `kong prepare`

### DIFF
--- a/app/docs/0.11.x/configuration.md
+++ b/app/docs/0.11.x/configuration.md
@@ -227,9 +227,14 @@ $ kong prepare -p /usr/local/kong -c /path/to/kong.conf
 ```
 
 The above command generates `nginx.conf` and `nginx-kong.conf` in
-`/usr/local/kong`. You can then start OpenResty with this configuration,
-possibly editing this freshly-generated `nginx.conf` file to further customize
-it.
+`/usr/local/kong`. Note that these two files get overwritten if they
+already exist. `kong prepare` also creates log files in `logs/` and
+default self-generated SSL certificates in `ssl/`, but only if these
+don't exist already.
+
+Once this configuration is prepared with `kong prepare`, you can then
+start OpenResty using it, possibly editing this freshly-generated
+`nginx.conf` file to further customize it.
 
 ```
 $ nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf

--- a/app/docs/0.11.x/configuration.md
+++ b/app/docs/0.11.x/configuration.md
@@ -252,6 +252,17 @@ use the `--nginx-conf` flag with `kong prepare`:
 $ kong prepare -p /usr/local/kong -c /path/to/kong.conf --nginx-conf custom_nginx.template
 ```
 
+So, in short:
+
+ * `kong prepare` reads `kong.conf` with `-c` (and optionally a custom
+template with `--nginx-conf`;
+ * This generates `nginx.conf` and `nginx-kong.conf` and prepares the
+environment for Nginx to run loading Kong. The generated `nginx.conf`
+includes `nginx-kong.conf`;
+ * Launching Nginx with the Kong-generated `nginx.conf` (or your custom
+configuration which includes `nginx-kong.conf`) causes Kong to be loaded
+in it.
+
 [Back to TOC](#table-of-contents)
 
 ### Properties reference


### PR DESCRIPTION
Update documentation to refer to `kong prepare` instead of `kong compile`, matching the feature set for 0.11. I also revised the entire section for customized Nginx setups, based on my experience learning my way around it, hopefully making it clearer.
