### PR TITLE
feat(install) update download locations

### DIFF
--- a/app/install/aws-linux.md
+++ b/app/install/aws-linux.md
@@ -11,7 +11,7 @@ breadcrumbs:
 
 Start by downloading the following package specifically built for the Amazon Linux AMI:
 
-- [Download]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.aws.rpm)
+- [Download]({{ site.links.download }}/kong-community-edition-aws/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.aws.rpm)
 
 ----
 
@@ -23,7 +23,7 @@ Start by downloading the following package specifically built for the Amazon Lin
 
     ```bash
     $ sudo yum install epel-release
-    $ sudo yum install kong-{{site.data.kong_latest.version}}.aws.rpm --nogpgcheck
+    $ sudo yum install kong-community-edition-{{site.data.kong_latest.version}}.aws.rpm --nogpgcheck
     ```
 
 2. **Prepare your database**

--- a/app/install/centos.md
+++ b/app/install/centos.md
@@ -11,15 +11,15 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [CentOS 6]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el6.noarch.rpm)
-- [CentOS 7]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el7.noarch.rpm)
+- [CentOS 6]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.el6.noarch.rpm)
+- [CentOS 7]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.el7.noarch.rpm)
 
 ### YUM Repositories
 
-You can also install Kong by using the following YUM repositories and following the Bintray instructions:
+You can also install Kong via YUM; follow the instructions on the "Set Me Up"
+section on the page below.
 
-- [CentOS 6 YUM](https://bintray.com/mashape/kong-rpm-el6-{{site.data.kong_latest.release}})
-- [CentOS 7 YUM](https://bintray.com/mashape/kong-rpm-el7-{{site.data.kong_latest.release}})
+- [RPM Repository](https://bintray.com/kong/kong-community-edition-rpm)
 
 ----
 
@@ -31,7 +31,7 @@ You can also install Kong by using the following YUM repositories and following 
 
     ```bash
     $ sudo yum install epel-release
-    $ sudo yum install kong-{{site.data.kong_latest.version}}.*.noarch.rpm --nogpgcheck
+    $ sudo yum install kong-community-edition-{{site.data.kong_latest.version}}.*.noarch.rpm --nogpgcheck
     ```
 
 2. **Prepare your database**

--- a/app/install/debian.md
+++ b/app/install/debian.md
@@ -11,15 +11,17 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [7 Wheezy]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.wheezy_all.deb)
-- [8 Jessie]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.jessie_all.deb)
+- [7 Wheezy]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.wheezy.all.deb)
+- [8 Jessie]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.jessie.all.deb)
+- [9 Stretch]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.stretch.all.deb)
 
 ### APT Repositories
 
-You can also install Kong by using the following APT repositories and following the Bintray instructions:
+You can also install Kong via APT; follow the instructions on the "Set Me Up"
+section on the page below, setting  *distribution* to the appropriate value
+(e.g., `wheezy`) and *components* to `main`.
 
-- [7 Wheezy APT](https://bintray.com/mashape/kong-debian-wheezy-{{site.data.kong_latest.release}})
-- [8 Jessie APT](https://bintray.com/mashape/kong-debian-jessie-{{site.data.kong_latest.release}})
+- [Deb Repository](https://bintray.com/kong/kong-community-edition-deb)
 
 ----
 
@@ -32,7 +34,7 @@ You can also install Kong by using the following APT repositories and following 
     ```bash
     $ sudo apt-get update
     $ sudo apt-get install openssl libpcre3 procps perl
-    $ sudo dpkg -i kong-{{site.data.kong_latest.version}}.*.deb
+    $ sudo dpkg -i kong-community-edition-{{site.data.kong_latest.version}}.*.deb
     ```
 
 2. **Prepare your database**

--- a/app/install/osx.md
+++ b/app/install/osx.md
@@ -9,7 +9,6 @@ breadcrumbs:
 
 ### Packages
 
-- [.pkg Installer]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.osx.pkg)
 - [Homebrew Formula]({{ site.repos.homebrew }})
 
 ----
@@ -18,9 +17,12 @@ breadcrumbs:
 
 1. **Install Kong**
 
-    Use the `.pkg` installer or the Homebrew formula. For the Homebrew formula, follow the instructions described in the repository.
+    Use the [Homebrew](https://brew.sh/) package manager to add Kong as a tap and install it:
 
-    **Note**: After downloading the `.pkg` installer, you will have to **right click**, select "Open" and authorize it.
+    ```
+    $ brew tap mashape/kong
+    $ brew install kong
+    ```
 
 2. **Prepare your database**
 

--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -13,15 +13,15 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [RHEL 6]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el6.noarch.rpm)
-- [RHEL 7]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.el7.noarch.rpm)
+- [RHEL 6]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.el6.noarch.rpm)
+- [RHEL 7]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.el7.noarch.rpm)
 
 ### YUM Repositories
 
-You can also install Kong by using the following YUM repositories and following the Bintray instructions:
+You can also install Kong via YUM; follow the instructions on the "Set Me Up"
+section on the page below.
 
-- [RHEL 6 YUM](https://bintray.com/mashape/kong-rpm-el6-{{site.data.kong_latest.release}})
-- [RHEL 7 YUM](https://bintray.com/mashape/kong-rpm-el7-{{site.data.kong_latest.release}})
+- [RPM Repository](https://bintray.com/kong/kong-community-edition-rpm)
 
 ----
 
@@ -41,7 +41,7 @@ You can also install Kong by using the following YUM repositories and following 
     If you are downloading the [package](#packages), execute:
 
     ```bash
-    $ sudo yum install kong-{{site.data.kong_latest.version}}.*.noarch.rpm --nogpgcheck
+    $ sudo yum install kong-community-edition-{{site.data.kong_latest.version}}.*.noarch.rpm --nogpgcheck
     ```
 
 3. **Prepare your database**

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -11,19 +11,18 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [12.04 Precise]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.precise_all.deb)
-- [14.04 Trusty]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.trusty_all.deb)
-- [15.04 Vivid]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.vivid_all.deb)
-- [16.04 Xenial]({{ site.links.download }}/{{site.data.kong_latest.version}}/kong-{{site.data.kong_latest.version}}.xenial_all.deb)
+- [12.04 Precise]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.precise.all.deb)
+- [14.04 Trusty]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.trusty.all.deb)
+- [16.04 Xenial]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.xenial.all.deb)
+- [17.04 Zesty]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.zesty.all.deb)
 
 ### APT Repositories
 
-You can also install Kong by using the following APT repositories and following the Bintray instructions:
+You can also install Kong via APT; follow the instructions on the "Set Me Up"
+section on the page below, setting  *distribution* to the appropriate value
+(e.g., `precise`) and *components* to `main`.
 
-- [12.04 Precise APT](https://bintray.com/mashape/kong-ubuntu-precise-{{site.data.kong_latest.release}})
-- [14.04 Trusty APT](https://bintray.com/mashape/kong-ubuntu-trusty-{{site.data.kong_latest.release}})
-- [15.04 Vivid APT](https://bintray.com/mashape/kong-ubuntu-vivid-{{site.data.kong_latest.release}})
-- [16.04 Xenial APT](https://bintray.com/mashape/kong-ubuntu-xenial-{{site.data.kong_latest.release}})
+- [Deb Repository](https://bintray.com/kong/kong-community-edition-deb)
 
 ----
 
@@ -36,7 +35,7 @@ You can also install Kong by using the following APT repositories and following 
     ```bash
     $ sudo apt-get update
     $ sudo apt-get install openssl libpcre3 procps perl
-    $ sudo dpkg -i kong-{{site.data.kong_latest.version}}.*.deb
+    $ sudo dpkg -i kong-community-edition-{{site.data.kong_latest.version}}.*.deb
     ```
 
 2. **Prepare your database**

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -26,7 +26,7 @@ documentation: docs
 links:
   web: https://getkong.org
   share: http://getkong.org # legacy link, must maintain for social sharing counters
-  download: https://github.com/Mashape/kong/releases/download
+  download: https://bintray.com/kong
   instaclustr: "https://www.instaclustr.com/products/kong/?utm_source=partnership&utm_medium=link&utm_campaign=mashape"
 repos:
   kong: https://github.com/Mashape/kong


### PR DESCRIPTION
WIP

* Update download locations to point to Bintray (yay);
* Update package names - `kong` is now `kong-community-edition`
* Add Debian 9 and Ubuntu Zesty;
* Remove OSX `.pkg` from the intall page - use Homebrew instead.