### PR TITLE
fix(docs): Fix example in entities cache: Use dao find_all method instead of find_by_keys

### DIFF
--- a/app/docs/0.10.x/plugin-development/entities-cache.md
+++ b/app/docs/0.10.x/plugin-development/entities-cache.md
@@ -73,7 +73,7 @@ Bringing back our authentication plugin example, to lookup a credential with a s
 local function load_entity_key(api_key)
   -- IMPORTANT: the callback is executed inside a lock, hence we cannot terminate
   -- a request here, we MUST always return.
-  local apikeys, err = dao.apikeys:find_by_keys({key = api_key}) -- Lookup in the datastore
+  local apikeys, err = dao.apikeys:find_all({key = api_key}) -- Lookup in the datastore
   if err then
     return nil, err     -- errors must be returned, not dealt with here
   end

--- a/app/docs/0.11.x/plugin-development/entities-cache.md
+++ b/app/docs/0.11.x/plugin-development/entities-cache.md
@@ -87,7 +87,7 @@ local singletons = require "kong.singletons"
 local function load_entity_key(api_key)
   -- IMPORTANT: the callback is executed inside a lock, hence we cannot terminate
   -- a request here, we MUST always return.
-  local apikeys, err = dao.apikeys:find_by_keys({key = api_key}) -- Lookup in the datastore
+  local apikeys, err = dao.apikeys:find_all({key = api_key}) -- Lookup in the datastore
   if err then
     error(err) -- caught by kong.cache and logged
   end

--- a/app/docs/0.8.x/plugin-development/entities-cache.md
+++ b/app/docs/0.8.x/plugin-development/entities-cache.md
@@ -64,7 +64,7 @@ if apikey then -- If the apikey has been passed, we can check if it exists
   -- If it's not, then we lookup the datastore and return the credential object. Internally
   -- cache.get_or_set will save the value in-memory, and then return the credential.
   credential = cache.get_or_set("apikeys."..apikey, function()
-    local apikeys, err = dao.apikeys:find_by_keys({key = apikey}) -- Lookup in the datastore
+    local apikeys, err = dao.apikeys:find_all({key = apikey}) -- Lookup in the datastore
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     elseif #apikeys == 1 then

--- a/app/docs/0.9.x/plugin-development/entities-cache.md
+++ b/app/docs/0.9.x/plugin-development/entities-cache.md
@@ -64,7 +64,7 @@ if apikey then -- If the apikey has been passed, we can check if it exists
   -- If it's not, then we lookup the datastore and return the credential object. Internally
   -- cache.get_or_set will save the value in-memory, and then return the credential.
   credential = cache.get_or_set("apikeys."..apikey, function()
-    local apikeys, err = dao.apikeys:find_by_keys({key = apikey}) -- Lookup in the datastore
+    local apikeys, err = dao.apikeys:find_all({key = apikey}) -- Lookup in the datastore
     if err then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     elseif #apikeys == 1 then


### PR DESCRIPTION
In DAO docs, the method `find_by_keys` doesn't exist since version 0.8.x.