### PR TITLE
docs(configuration) fix a small typo in the example templates

### DIFF
--- a/app/docs/0.11.x/configuration.md
+++ b/app/docs/0.11.x/configuration.md
@@ -147,7 +147,7 @@ user ${{"{{NGINX_USER"}}}};
 > end
 
 worker_processes ${{"{{NGINX_WORKER_PROCESSES"}}}};
-daemon ${{"{[NGINX_DAEMON"}}}};
+daemon ${{"{{NGINX_DAEMON"}}}};
 
 pid pids/nginx.pid;
 error_log ${{"{{PROXY_ERROR_LOG"}}}} ${{"{{LOG_LEVEL"}}}};
@@ -199,7 +199,7 @@ user ${{"{{NGINX_USER"}}}};
 > end
 
 worker_processes ${{"{{NGINX_WORKER_PROCESSES"}}}};
-daemon ${{"{[NGINX_DAEMON"}}}};
+daemon ${{"{{NGINX_DAEMON"}}}};
 
 pid pids/nginx.pid;
 error_log ${{"{{PROXY_ERROR_LOG"}}}} ${{"{{LOG_LEVEL"}}}};


### PR DESCRIPTION
There was a typo in the examples for custom configs, making them unable to copy and paste.